### PR TITLE
"Flat Theme" support

### DIFF
--- a/MUSHclient/lua/aardmapper.lua
+++ b/MUSHclient/lua/aardmapper.lua
@@ -170,7 +170,7 @@ local function build_room_info ()
 end -- build_room_info
 
 -- assorted colours
-BACKGROUND_COLOUR     = { name = "Area Background",  colour =  ColourNameToRGB "#111111"}
+BACKGROUND_COLOUR     = { name = "Area Background",  colour = ColourNameToRGB "#11111"}
 ROOM_COLOUR           = { name = "Room",             colour =  ColourNameToRGB "#dcdcdc"}
 EXIT_COLOUR           = { name = "Exit",             colour =  ColourNameToRGB "#e0ffff"}
 EXIT_COLOUR_UP_DOWN   = { name = "Exit up/down",     colour =  ColourNameToRGB "#ffb6c1"}
@@ -209,6 +209,8 @@ default_config = {
 
    -- how far from where we are standing to draw (rooms)
    SCAN = { depth = 300 },
+
+   FLAT_THEME = {enabled = false},
 
    -- show custom tiling background textures
    USE_TEXTURES = { enabled = true },
@@ -322,7 +324,7 @@ end -- get_number_from_user
 
 local function draw_configuration ()
 
-   local config_entries = {"Map Configuration", "Show Room ID", "Show Area Exits", "Font", "Depth", "Area Textures", "Room size"}
+   local config_entries = {"Map Configuration", "Show Room ID", "Show Area Exits", "Font", "Flat Theme", "Depth", "Area Textures", "Room size"}
    local width =  max_text_width (config_win, CONFIG_FONT_ID, config_entries , true)
    local GAP = 5
 
@@ -332,6 +334,7 @@ local function draw_configuration ()
    local rh_size = math.max (box_size, max_text_width (config_win, CONFIG_FONT_ID,
       {config.FONT.name .. " " .. config.FONT.size,
       ((config.USE_TEXTURES.enabled and "On") or "Off"),
+      ((config.FLAT_THEME.enabled and "On") or "Off"),
       "- +",
       tostring (config.SCAN.depth)},
       true))
@@ -415,6 +418,23 @@ local function draw_configuration ()
       "Click to change font",
       miniwin.cursor_hand, 0)  -- hand cursor
    y = y + font_height
+
+   -- flat Theme
+   WindowText(config_win, CONFIG_FONT_ID, "Flat Theme", x, y, 0, 0, 0x000000)
+   WindowText(config_win, CONFIG_FONT_ID_UL, ((config.FLAT_THEME.enabled and "On") or "Off"), width + rh_size / 2 + box_size - WindowTextWidth(config_win, CONFIG_FONT_ID_UL, ((config.FLAT_THEME.enabled  and "On") or "Off"))/2, y, 0, 0, 0x808080)
+
+   -- flat theme hotspot
+   WindowAddHotspot(config_win,
+      "$<flat_theme>",
+      x + GAP,
+      y,
+      x + frame_width,
+      y + font_height,   -- rectangle
+      "", "", "", "", "mapper.mouseup_flat_theme",  -- mouseup
+      "Click to toggle use of the flat theme",
+      miniwin.cursor_hand, 0)  -- hand cursor
+   y = y + font_height
+
 
    -- area textures
    WindowText(config_win, CONFIG_FONT_ID, "Area Textures", x, y, 0, 0, 0x000000)
@@ -733,8 +753,12 @@ end -- changed_room
 local function draw_zone_exit (exit)
    local x, y, def = exit.x, exit.y, exit.def
    local offset = ROOM_SIZE
-
-   WindowLine (win, x + def.x1, y + def.y1, x + def.x2, y + def.y2, ColourNameToRGB("yellow"), miniwin.pen_solid + 0x0200, 5)
+   local pen_width = 5
+   if config.FLAT_THEME.enabled == true then
+      pen_width = 2
+   end
+      
+   WindowLine (win, x + def.x1, y + def.y1, x + def.x2, y + def.y2, ColourNameToRGB("yellow"), miniwin.pen_solid + 0x0200, pen_width)
    WindowLine (win, x + def.x1, y + def.y1, x + def.x2, y + def.y2, ColourNameToRGB("green"), miniwin.pen_solid + 0x0200, 1)
 end --  draw_zone_exit
 
@@ -1636,6 +1660,19 @@ function mouseup_change_depth (flags, hotspot_id)
    draw (current_room)
 end -- mouseup_change_depth
 
+function mouseup_flat_theme (flags, hotspot_id)
+   if config.FLAT_THEME.enabled == true then
+      config.FLAT_THEME.enabled = false
+      BACKGROUND_COLOUR     = { name = "Area Background", colour = ColourNameToRGB "#11111"}
+      ROOM_COLOUR           = { name = "Room",             colour =  ColourNameToRGB "#dcdcdc"}
+   else
+      config.FLAT_THEME.enabled = true
+      BACKGROUND_COLOUR     = { name = "Area Background",  colour =  ColourNameToRGB "#1c1c1c"}
+      ROOM_COLOUR           = { name = "Room",             colour =  ColourNameToRGB "#303030"}
+   end
+   draw (current_room)
+end -- mouseup_flat_theme
+
 function mouseup_change_area_textures (flags, hotspot_id)
    if config.USE_TEXTURES.enabled == true then
       config.USE_TEXTURES.enabled = false
@@ -1721,15 +1758,23 @@ function add_resize_tag()
    -- draw the resize widget bottom right corner.
    local width  = WindowInfo(win, 3)
    local height = WindowInfo(win, 4)
+   
+   if config.FLAT_THEME.enabled == true then
+      resize_col_1 = 0x303030
+      resize_col_2 = 0x1c1c1c
+   else
+      resize_col_1 = 0xffffff
+      resize_col_2 = 0x696969
+   end
 
-   WindowLine(win, width-4, height-2, width-2, height-4, 0xffffff, 0, 2)
-   WindowLine(win, width-5, height-2, width-2, height-5, 0x696969, 0, 1)
-   WindowLine(win, width-7, height-2, width-2, height-7, 0xffffff, 0, 2)
-   WindowLine(win, width-8, height-2, width-2, height-8, 0x696969, 0, 1)
-   WindowLine(win, width-10, height-2, width-2, height-10, 0xffffff, 0, 2)
-   WindowLine(win, width-11, height-2, width-2, height-11, 0x696969, 0, 1)
-   WindowLine(win, width-13, height-2, width-2, height-13, 0xffffff, 0, 2)
-   WindowLine(win, width-14, height-2, width-2, height-14, 0x696969, 0, 1)
+   WindowLine(win, width-4, height-2, width-2, height-4, resize_col_1, 0, 2)
+   WindowLine(win, width-5, height-2, width-2, height-5, resize_col_2, 0, 1)
+   WindowLine(win, width-7, height-2, width-2, height-7, resize_col_1, 0, 2)
+   WindowLine(win, width-8, height-2, width-2, height-8, resize_col_2, 0, 1)
+   WindowLine(win, width-10, height-2, width-2, height-10, resize_col_1, 0, 2)
+   WindowLine(win, width-11, height-2, width-2, height-11, resize_col_2, 0, 1)
+   WindowLine(win, width-13, height-2, width-2, height-13, resize_col_1, 0, 2)
+   WindowLine(win, width-14, height-2, width-2, height-14, resize_col_2, 0, 1)
 
    -- Hotspot for resizer.
    local x = width - 14
@@ -1748,6 +1793,10 @@ end -- draw resize tag.
 
 function draw_edge()
    -- draw edge frame.
-   check (WindowRectOp (win, 1, 0, 0, 0, 0, 0xE8E8E8, 15))
-   check (WindowRectOp (win, 1, 1, 1, -1, -1, 0x777777, 15))
+   if config.FLAT_THEME.enabled == true then
+      check (WindowRectOp (win, 1, 0, 0, 0, 0, 0x303030, 15))
+   else
+      check (WindowRectOp (win, 1, 0, 0, 0, 0, 0xE8E8E8, 15))
+      check (WindowRectOp (win, 1, 1, 1, -1, -1, 0x777777, 15))
+   end
 end

--- a/MUSHclient/lua/aardmapper.lua
+++ b/MUSHclient/lua/aardmapper.lua
@@ -67,6 +67,7 @@ require "gauge"
 require "pairsbykeys"
 require "mw"
 
+
 local FONT_ID     = "fn"  -- internal font identifier
 local FONT_ID_UL  = "fnu" -- internal font identifier - underlined
 local CONFIG_FONT_ID = "cfn"
@@ -170,8 +171,7 @@ local function build_room_info ()
 end -- build_room_info
 
 -- assorted colours
-BACKGROUND_COLOUR     = { name = "Area Background",  colour = ColourNameToRGB "#11111"}
-ROOM_COLOUR           = { name = "Room",             colour =  ColourNameToRGB "#dcdcdc"}
+-- Area and Room colors initialized in init() for theme support
 EXIT_COLOUR           = { name = "Exit",             colour =  ColourNameToRGB "#e0ffff"}
 EXIT_COLOUR_UP_DOWN   = { name = "Exit up/down",     colour =  ColourNameToRGB "#ffb6c1"}
 ROOM_NOTE_COLOUR      = { name = "Room notes",       colour =  ColourNameToRGB "lightgreen"}
@@ -1042,6 +1042,14 @@ function init (t)
    show_other_areas = t.show_other_areas  -- true to show other areas
    show_up_down = t.show_up_down        -- true to show up or down
    speedwalk_prefix = t.speedwalk_prefix  -- how to speedwalk (prefix)
+
+   if config.FLAT_THEME.enabled == false then
+     BACKGROUND_COLOUR     = { name = "Area Background", colour = ColourNameToRGB "#11111"}
+     ROOM_COLOUR           = { name = "Room",             colour =  ColourNameToRGB "#dcdcdc"}
+   else
+     BACKGROUND_COLOUR     = { name = "Area Background",  colour =  ColourNameToRGB "#1c1c1c"}
+     ROOM_COLOUR           = { name = "Room",             colour =  ColourNameToRGB "#303030"}
+   end
 
    -- force some config defaults if not supplied
    for k, v in pairs (default_config) do

--- a/MUSHclient/worlds/plugins/aard_ASCII_map.xml
+++ b/MUSHclient/worlds/plugins/aard_ASCII_map.xml
@@ -170,11 +170,19 @@ require "gmcphelper"
 require "movewindow"
 require "mw"
 
-background_colour     = GetNormalColour(1)
+flat_theme = tonumber(GetVariable("flat_theme")) or 0
+if flat_theme == 1 then
+  background_colour = 0x1c1c1c
+  border_color = 0x444444
+  title_gradient_col1 = 0x303030
+  title_gradient_col2 = 0x303030
+else
+  background_colour     = GetNormalColour(1)
+  border_color        = 0xdddddd
+  title_gradient_col1 = GetNormalColour(1)
+  title_gradient_col2 = 0x444444
+end
 title_colour          = 0x292929
-border_color          = 0xdddddd
-title_gradient_col1   = GetNormalColour(1)
-title_gradient_col2   = 0x444444
 default_width         = 209
 default_height        = 263
 default_x             = 658
@@ -347,7 +355,9 @@ function DisplayMapPage()
    if show_title == 1 then
       -- title rectangle
       WindowGradient (win, 2, 2, -2, TITLE_HEIGHT, title_gradient_col1, title_gradient_col2, 2)
-      WindowLine(win,0,TITLE_HEIGHT,width,TITLE_HEIGHT,0xeeeeee,0,1)
+      if flat_theme == 0 then
+         WindowLine(win,0,TITLE_HEIGHT,width,TITLE_HEIGHT,0xeeeeee,0,1)
+      end
    end
 
    -- show the widget for the legend popup
@@ -396,17 +406,26 @@ function DisplayMapPage()
 
    -- draw edge frame.
    WindowRectOp (win, 1, 0, 0, 0, 0, border_color, 15)
-   WindowRectOp (win, 1, 1, 1, -1, -1, 0x777777, 15)
+   if flat_theme == 0 then
+      WindowRectOp (win, 1, 1, 1, -1, -1, 0x777777, 15)
+   end
 
    -- draw the resize widget bottom right corner.
-   WindowLine(win, width-3, height-2, width-2, height-3, 0xffffff, 0, 2)
-   WindowLine(win, width-4, height-2, width-2, height-4, 0x696969, 0, 1)
-   WindowLine(win, width-6, height-2, width-2, height-6, 0xffffff, 0, 2)
-   WindowLine(win, width-7, height-2, width-2, height-7, 0x696969, 0, 1)
-   WindowLine(win, width-9, height-2, width-2, height-9, 0xffffff, 0, 2)
-   WindowLine(win, width-10, height-2, width-2, height-10, 0x696969, 0, 1)
-   WindowLine(win, width-12, height-2, width-2, height-12, 0xffffff, 0, 2)
-   WindowLine(win, width-13, height-2, width-2, height-13, 0x696969, 0, 1)
+   if flat_theme == 1 then
+      resize_col_1 = 0x303030
+      resize_col_2 = 0x1c1c1c
+   else
+      resize_col_1 = 0xffffff
+      resize_col_2 = 0x696969
+   end
+   WindowLine(win, width-3, height-2, width-2, height-3, resize_col_1, 0, 2)
+   WindowLine(win, width-4, height-2, width-2, height-4, resize_col_2, 0, 1)
+   WindowLine(win, width-6, height-2, width-2, height-6, resize_col_1, 0, 2)
+   WindowLine(win, width-7, height-2, width-2, height-7, resize_col_2, 0, 1)
+   WindowLine(win, width-9, height-2, width-2, height-9, resize_col_1, 0, 2)
+   WindowLine(win, width-10, height-2, width-2, height-10, resize_col_2, 0, 1)
+   WindowLine(win, width-12, height-2, width-2, height-12, resize_col_1, 0, 2)
+   WindowLine(win, width-13, height-2, width-2, height-13, resize_col_2, 0, 1)
 
    -- show it now (or refresh)
    WindowShow (win, true)
@@ -484,7 +503,9 @@ end -- Display_Line
 -- right click menu
 function right_click_menu ()
 
-   menustring = "Change Font|>Map Type|"
+   menustring = "Change Font|"
+   menustring = menustring .. ((flat_theme==1 and "+") or "").."Flat Theme|"
+   menustring = menustring .. ">Map Type|"
    menustring = menustring .. ((maptype == 0 and "+") or "") .. "0 - Standard ASCII based map|"
    menustring = menustring .. ((maptype == 1 and "+") or "") .. "1 - Solid single line map|"
    menustring = menustring .. ((maptype == 2 and "+") or "") .. "2 - Solid double line map|"
@@ -516,6 +537,21 @@ function right_click_menu ()
          font_name = wanted_font.name
          font_size = wanted_font.size
       end
+   elseif result == "Flat Theme" then
+      if flat_theme == 0 then
+         ColourNote ("yellow", "", "Flat Theme for ascii map is ENABLED.")
+         background_colour = 0x1c1c1c
+         border_color = 0x303030
+         title_gradient_col1 = 0x303030 
+         title_gradient_col2 = 0x303030
+      else  
+         ColourNote ("yellow", "", "Flat Theme for ascii map is DISABLED.")
+         background_colour = 0x000000 
+         border_color = 0xcccccc
+         title_gradient_col1 = GetNormalColour(1)
+         title_gradient_col2 = 0x444444
+      end
+      flat_theme = (((0 == flat_theme) and 1) or 0) 
    elseif result == "Bring To Front" then
       CallPlugin("462b665ecb569efbf261422f","boostMe", win)
    elseif result == "Send To Back" then
@@ -781,6 +817,7 @@ function OnPluginSaveState ()
    SetVariable ("showtitle", show_title)
    SetVariable ("font_name", font_name)
    SetVariable ("font_size", font_size)
+   SetVariable ("flat_theme", flat_theme)
    SetVariable ("also_echo_map", also_echo_map)
    SetVariable ("maptype", maptype)
 end -- OnPluginSaveState
@@ -848,6 +885,7 @@ function OnPluginInstall(skip_requests)
    show_exits = tonumber (GetVariable ("showexits")) or 0
    show_title = tonumber (GetVariable ("showtitle")) or 1
    also_echo_map = tonumber (GetVariable("also_echo_map")) or 0
+   flat_theme = tonumber (GetVariable("flat_theme")) or 0
 
    -- make window so I can grab the font info
    WindowCreate (win, 1, 1, width, height, 0, 0, background_colour)

--- a/MUSHclient/worlds/plugins/aard_GMCP_mapper.xml
+++ b/MUSHclient/worlds/plugins/aard_GMCP_mapper.xml
@@ -2135,12 +2135,12 @@ function get_room (uid)
 
    if uid == current_room then
       room.bordercolour = mapper.OUR_ROOM_COLOUR.colour
-      room.borderpenwidth = 3
+      room.borderpenwidth = 2
    elseif room.area ~= current_area then
       room.bordercolour = mapper.DIFFERENT_AREA_COLOUR.colour
    elseif room.info and string.match(room.info, "pk") then
       room.bordercolour = mapper.PK_BORDER_COLOUR.colour
-      room.borderpenwidth = 3
+      room.borderpenwidth = 2
    end -- not in this area
 
    return room

--- a/MUSHclient/worlds/plugins/aard_channels_fiendish.xml
+++ b/MUSHclient/worlds/plugins/aard_channels_fiendish.xml
@@ -596,7 +596,7 @@ function drawStuff ()
       WindowDragHandler(win, "scroller", "ScrollerMoveCallback", "ScrollerReleaseCallback", 0)
    end
    if flat_theme == 1 then
-      WindowRectOp(win, 4, (width-SCROLL_BAR_WIDTH), barPos, width, barPos+barSize, 0x303030, 0x444444) -- scrollbar position indicator
+      WindowRectOp(win, 4, (width-SCROLL_BAR_WIDTH), barPos, width, barPos+barSize, 0x444444, 0x333333) -- scrollbar position indicator
    else
       WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), barPos, width, barPos+barSize, 5, 15 + 0x800) -- scrollbar position indicator
    end

--- a/MUSHclient/worlds/plugins/aard_channels_fiendish.xml
+++ b/MUSHclient/worlds/plugins/aard_channels_fiendish.xml
@@ -142,14 +142,25 @@ height = tonumber(GetVariable("WINDOW_HEIGHT")) or default_height
 log_to_file = tonumber(GetVariable("log_to_file")) or 0
 log_colour_codes = tonumber(GetVariable("log_colour_codes")) or 1
 log_timestamps = tonumber(GetVariable("log_timestamps")) or 1
+flat_theme = tonumber(GetVariable("flat_theme")) or 0
 
 -- colours
-WINDOW_BACKGROUND_COLOUR = GetNormalColour(1)
+if flat_theme == 1 then
+   WINDOW_BACKGROUND_COLOUR = 0x1c1c1c
+   WINDOW_BORDER_COLOUR = 0x303030
+   SCROLL_BACKGROUND_COLOUR = 0x1c1c1c
+   SCROLL_BAR_COLOUR = 0x303030
+   SCROLL_DETAIL_COLOUR = 0x111111
+else
+   WINDOW_BACKGROUND_COLOUR = GetNormalColour(1)
+   WINDOW_BORDER_COLOUR = 0xE8E8E8
+   SCROLL_BACKGROUND_COLOUR = 0xE8E8E8
+   SCROLL_BAR_COLOUR = 0x111111
+   SCROLL_DETAIL_COLOUR = 0x000000
+end
+
 WINDOW_TEXT_COLOUR = 0xffffff
-SCROLL_BACKGROUND_COLOUR = 0xE8E8E8
-SCROLL_BAR_COLOUR = 0x111111
-SCROLL_DETAIL_COLOUR = 0x000000
-WINDOW_BORDER_COLOUR = 0xE8E8E8
+
 
 -- offset of text from edge
 TEXT_INSET = 5
@@ -171,6 +182,7 @@ windowinfo = ""
 startx = ""
 starty = ""
 
+
 show_donations = tonumber(GetVariable("show_donations")) or 1
 info_on = tonumber(GetVariable("info_on")) or 0
 global_quest_on = tonumber(GetVariable("global_quest_on")) or 0
@@ -188,6 +200,7 @@ function reset_aard()
    height = default_height
    font_name = default_font_name
    font_size = default_font_size
+   flat_theme = 0
    windowinfo.window_left = default_x
    windowinfo.window_top = default_y
    WindowPosition(win, default_x, default_y, 0, 18)
@@ -335,23 +348,40 @@ function init (firstTime)
 
    -- title rectangle
    header_width = WindowTextWidth(win, win_head_font, "Communication Log")
-   WindowGradient(win, 1, 0, width, TITLE_HEIGHT, WINDOW_BACKGROUND_COLOUR, 0x444444, 2)
+   if flat_theme == 1 then
+      WindowGradient(win, 2, 2, -2, TITLE_HEIGHT, 0x444444, 0x444444, 2)
+   else
+      WindowGradient(win, 1, 0, width, TITLE_HEIGHT, WINDOW_BACKGROUND_COLOUR, 0x444444, 2)
+      WindowLine(win, 0, TITLE_HEIGHT-1, width, TITLE_HEIGHT-1, WINDOW_BORDER_COLOUR, 0 + 0x0200, 1)
+   end
    WindowText(win, win_head_font, "Communication Log", (width-header_width)/2, ((TITLE_HEIGHT-header_font_height)/2)-1, width, TITLE_HEIGHT, 0xEEEEEE, false)
-   WindowLine(win, 0, TITLE_HEIGHT-1, width, TITLE_HEIGHT-1, WINDOW_BORDER_COLOUR, 0 + 0x0200, 1)
-
+   
    -- resize tag
-   WindowRectOp(win, 2, width-SCROLL_BAR_WIDTH, height-SCROLL_BAR_WIDTH, 0, 0, SCROLL_BACKGROUND_COLOUR) -- resizer background
-   WindowLine(win, width-SCROLL_BAR_WIDTH+1, height-2, width-2, height-SCROLL_BAR_WIDTH+1, 0xffffff, 0, 2)
-   WindowLine(win, width-SCROLL_BAR_WIDTH+2, height-2, width-2, height-SCROLL_BAR_WIDTH+2, 0x696969, 0, 1)
-   WindowLine(win, width-SCROLL_BAR_WIDTH+4, height-2, width-2, height-SCROLL_BAR_WIDTH+4, 0xffffff, 0, 2)
-   WindowLine(win, width-SCROLL_BAR_WIDTH+5, height-2, width-2, height-SCROLL_BAR_WIDTH+5, 0x696969, 0, 1)
-   WindowLine(win, width-SCROLL_BAR_WIDTH+7, height-2, width-2, height-SCROLL_BAR_WIDTH+7, 0xffffff, 0, 2)
-   WindowLine(win, width-SCROLL_BAR_WIDTH+8, height-2, width-2, height-SCROLL_BAR_WIDTH+8, 0x696969, 0, 1)
-   WindowLine(win, width-SCROLL_BAR_WIDTH+10, height-2, width-2, height-SCROLL_BAR_WIDTH+10, 0xffffff, 0, 2)
-   WindowLine(win, width-SCROLL_BAR_WIDTH+11, height-2, width-2, height-SCROLL_BAR_WIDTH+11, 0x696969, 0, 1)
+   if flat_theme == 1 then
+      resize_color_1 = 0x303030
+      resize_color_2 = 0x1c1c1c
+   else
+      resize_color_1 = 0xffffff
+      resize_color_2 = 0x696969
+   end
+   WindowRectOp(win, 2, width-SCROLL_BAR_WIDTH, height-SCROLL_BAR_WIDTH, 0, 0, 0x1c1c1c) -- resizer background
+   WindowLine(win, width-SCROLL_BAR_WIDTH+1, height-2, width-2, height-SCROLL_BAR_WIDTH+1, resize_color_1, 0, 2)
+   WindowLine(win, width-SCROLL_BAR_WIDTH+2, height-2, width-2, height-SCROLL_BAR_WIDTH+2, resize_color_2, 0, 1)
+   WindowLine(win, width-SCROLL_BAR_WIDTH+4, height-2, width-2, height-SCROLL_BAR_WIDTH+4, resize_color_1, 0, 2)
+   WindowLine(win, width-SCROLL_BAR_WIDTH+5, height-2, width-2, height-SCROLL_BAR_WIDTH+5, resize_color_2, 0, 1)
+   WindowLine(win, width-SCROLL_BAR_WIDTH+7, height-2, width-2, height-SCROLL_BAR_WIDTH+7, resize_color_1, 0, 2)
+   WindowLine(win, width-SCROLL_BAR_WIDTH+8, height-2, width-2, height-SCROLL_BAR_WIDTH+8, resize_color_2, 0, 1)
+   WindowLine(win, width-SCROLL_BAR_WIDTH+10, height-2, width-2, height-SCROLL_BAR_WIDTH+10, resize_color_1, 0, 2)
+   WindowLine(win, width-SCROLL_BAR_WIDTH+11, height-2, width-2, height-SCROLL_BAR_WIDTH+11, resize_color_2, 0, 1)
 
    -- draw border
-   WindowRectOp(win, 1, 0, 0, 0, 0, WINDOW_BORDER_COLOUR)
+   if flat_theme == 1 then
+      WindowRectOp (win, 1, 0, 0, 0, 0, 0x303030, 15)
+      WindowRectOp (win, 1, 1, 1, -1, -1, 0x444444, 15)
+   else
+      WindowRectOp(win, 1, 0, 0, 0, 0, WINDOW_BORDER_COLOUR)
+      WindowRectOp (win, 1, 1, 1, -1, -1, 0x777777, 15)
+   end 
 
    drawStuff()
 end
@@ -385,6 +415,7 @@ function OnPluginSaveState()
 
    SetVariable("font_name", font_name)
    SetVariable("font_size", font_size)
+   SetVariable("flat_theme", flat_theme)
    SetVariable("date_format", date_format)
    SetVariable("WINDOW_WIDTH", width)
    SetVariable("WINDOW_HEIGHT", height)
@@ -491,7 +522,11 @@ function drawStuff ()
 
    if (keepscrolling == "up") then
       -- draw top scroll button pressed
-      WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), TITLE_HEIGHT, 0, TITLE_HEIGHT+SCROLL_BAR_WIDTH, 10,  15 + 0x800) -- up arrow pushed
+      if flat_theme == 1 then
+         WindowRectOp(win, 4, (width-SCROLL_BAR_WIDTH), TITLE_HEIGHT, 0, TITLE_HEIGHT+SCROLL_BAR_WIDTH, 0x444444, 0x666666) -- up arrow pushed
+      else
+         WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), TITLE_HEIGHT, 0, TITLE_HEIGHT+SCROLL_BAR_WIDTH, 10, 15 + 0x800) -- up arrow pushed
+      end
       points = string.format("%i,%i,%i,%i,%i,%i", (width-SCROLL_BAR_WIDTH)+3, TITLE_HEIGHT+9,(width-SCROLL_BAR_WIDTH)+7, TITLE_HEIGHT+5,(width-SCROLL_BAR_WIDTH)+11, TITLE_HEIGHT+9)
       WindowPolygon(win, points,
          0x000000, 0, 1, -- pen (solid, width 1)
@@ -500,7 +535,11 @@ function drawStuff ()
          false) -- alt fill
    else
       -- draw top scroll button unpressed
-      WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), TITLE_HEIGHT, width, TITLE_HEIGHT+SCROLL_BAR_WIDTH, 5, 15 + 0x800)
+      if flat_theme == 1 then
+         WindowRectOp(win, 4, (width-SCROLL_BAR_WIDTH), TITLE_HEIGHT, width, TITLE_HEIGHT+SCROLL_BAR_WIDTH, 0x303030 , 0x444444)
+      else
+         WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), TITLE_HEIGHT, width, TITLE_HEIGHT+SCROLL_BAR_WIDTH, 5, 15 + 0x800)
+      end
       points = string.format("%i,%i,%i,%i,%i,%i", (width-SCROLL_BAR_WIDTH)+3, TITLE_HEIGHT+9,(width-SCROLL_BAR_WIDTH)+7, TITLE_HEIGHT+5,(width-SCROLL_BAR_WIDTH)+11, TITLE_HEIGHT+9)
       WindowPolygon(win, points,
          0x000000, 0, 1,   -- pen (solid, width 1)
@@ -511,7 +550,11 @@ function drawStuff ()
 
    if (keepscrolling == "down") then
       -- draw bottom scroll button pressed
-      WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), height-(SCROLL_BAR_WIDTH*2), 0, height-SCROLL_BAR_WIDTH-1, 10,  15 + 0x800)
+      if flat_theme == 1 then
+         WindowRectOp(win, 4, (width-SCROLL_BAR_WIDTH), height-(SCROLL_BAR_WIDTH*2), 0, height-SCROLL_BAR_WIDTH-1, 0x444444,  0x666666)
+      else
+         WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), height-(SCROLL_BAR_WIDTH*2), 0, height-SCROLL_BAR_WIDTH-1, 10, 15 + 0x800)
+      end
       points = string.format("%i,%i,%i,%i,%i,%i", (width-SCROLL_BAR_WIDTH)+3, (height-SCROLL_BAR_WIDTH)-11,(width-SCROLL_BAR_WIDTH)+7, (height-SCROLL_BAR_WIDTH)-7, (width-SCROLL_BAR_WIDTH)+11,(height-SCROLL_BAR_WIDTH)-11)
       WindowPolygon(win, points,
          0x000000, 0, 1, -- pen (solid, width 1)
@@ -520,7 +563,11 @@ function drawStuff ()
          false) -- alt fill
    else
       -- draw bottom scroll button unpressed
-      WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), height-(SCROLL_BAR_WIDTH*2), width, height-SCROLL_BAR_WIDTH, 5,  15 + 0x800)
+      if flat_theme == 1 then
+         WindowRectOp(win, 4, (width-SCROLL_BAR_WIDTH), height-(SCROLL_BAR_WIDTH*2), width, height-SCROLL_BAR_WIDTH, 0x303030, 0x444444)
+      else
+         WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), height-(SCROLL_BAR_WIDTH*2), 0, height-SCROLL_BAR_WIDTH-1, 5, 15 + 0x800)
+      end
       points = string.format("%i,%i,%i,%i,%i,%i", (width-SCROLL_BAR_WIDTH)+3, (height-SCROLL_BAR_WIDTH)-11,(width-SCROLL_BAR_WIDTH)+7, (height-SCROLL_BAR_WIDTH)-7, (width-SCROLL_BAR_WIDTH)+11,(height-SCROLL_BAR_WIDTH)-11)
       WindowPolygon(win, points,
          0x000000, 0, 1,   -- pen (solid, width 1)
@@ -548,7 +595,11 @@ function drawStuff ()
       WindowAddHotspot(win, "scroller", (width-SCROLL_BAR_WIDTH), barPos, width, barPos+barSize, "MouseOver", "CancelMouseOver", "MouseDown", "CancelMouseDown", "MouseUp", "", 1, 0)
       WindowDragHandler(win, "scroller", "ScrollerMoveCallback", "ScrollerReleaseCallback", 0)
    end
-   WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), barPos, width, barPos+barSize, 5, 15 + 0x800) -- scrollbar position indicator
+   if flat_theme == 1 then
+      WindowRectOp(win, 4, (width-SCROLL_BAR_WIDTH), barPos, width, barPos+barSize, 0x303030, 0x444444) -- scrollbar position indicator
+   else
+      WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), barPos, width, barPos+barSize, 5, 15 + 0x800) -- scrollbar position indicator
+   end
 
    -- reset hyperlinks if the text moves
    for k,v in pairs(hyperlinks) do
@@ -1103,7 +1154,7 @@ function right_click_menu (hotspot_id)
       menustring = menustring.."Go to URL: "..hyperlinks[hotspot_id].."|Copy URL to Clipboard|-|"
       url = hyperlinks[hotspot_id]
    end
-   menustring = menustring.."Copy Selected Without Colors|Copy Selected|Copy All|-|Change Font"
+   menustring = menustring.."Copy Selected Without Colors|Copy Selected|Copy All|-|Change Font|"..((flat_theme==1 and "+") or "").."Flat Theme"
    menustring = menustring .. "|>Timestamp|"..((date_format=="" and "+") or "").."No Timestamps|"..((date_format=="[%d %b %H:%M:%S] " and "+") or "").."30 Aug 13:29:49|"..((date_format=="[%d %b %I:%M:%S%p] " and "+") or "").."30 Aug 01:20:12PM|"..((date_format=="[%H:%M:%S] " and "+") or "").."13:29:08|"..((date_format=="[%I:%M:%S%p] " and "+") or "").."1:22:06 PM|<"
 
    menustring = menustring .. "|Customize Channels"
@@ -1164,21 +1215,40 @@ function right_click_menu (hotspot_id)
             OnPluginInstall()
          end
       elseif numResult == 5+hyperlink_skip then
+         if flat_theme == 0 then
+            ColourNote ("yellow", "", "Flat Theme for communication window is ENABLED.")
+            WINDOW_BACKGROUND_COLOUR = 0x1c1c1c
+            WINDOW_BORDER_COLOUR = 0x303030
+            SCROLL_BACKGROUND_COLOUR = 0x303030
+            SCROLL_BAR_COLOUR = 0x1c1c1c
+            SCROLL_DETAIL_COLOUR = 0x111111
+         else  
+            ColourNote ("yellow", "", "Flat Theme for communication window is DISABLED.")
+            WINDOW_BACKGROUND_COLOUR = GetNormalColour(1)
+            WINDOW_BORDER_COLOUR = 0xE8E8E8
+            SCROLL_BACKGROUND_COLOUR = 0xE8E8E8
+            SCROLL_BAR_COLOUR = 0x111111
+            SCROLL_DETAIL_COLOUR = 0x000000
+         end
+         flat_theme = (((0 == flat_theme) and 1) or 0)
+         SetVariable("flat_theme", flat_theme)
+         OnPluginInstall()
+      elseif numResult == 6+hyperlink_skip then
          date_format = ""
          ColourNote ("yellow", "", "Timestamps in communication window DISABLED.")
-      elseif numResult == 6+hyperlink_skip then
+      elseif numResult == 7+hyperlink_skip then
          date_format = "[%d %b %H:%M:%S] "
          ColourNote ("yellow", "", "Timestamps in communication window ENABLED using format like '30 Aug 13:29:49'.")
-      elseif numResult == 7+hyperlink_skip then
+      elseif numResult == 8+hyperlink_skip then
          date_format = "[%d %b %I:%M:%S%p] "
          ColourNote ("yellow", "", "Timestamps in communication window ENABLED using format like '30 Aug 01:20:12PM'.")
-      elseif numResult == 8+hyperlink_skip then
+      elseif numResult == 9+hyperlink_skip then
          date_format = "[%H:%M:%S] "
          ColourNote ("yellow", "", "Timestamps in communication window ENABLED using format like '13:29:08'.")
-      elseif numResult == 9+hyperlink_skip then
+      elseif numResult == 10+hyperlink_skip then
          date_format = "[%I:%M:%S%p] "
          ColourNote ("yellow", "", "Timestamps in communication window ENABLED using format like '1:22:06 PM'.")
-      elseif numResult == 10+hyperlink_skip then
+      elseif numResult == 11+hyperlink_skip then
          local tbl = {}
          local defaults = {}
          local i = 1
@@ -1193,7 +1263,7 @@ function right_click_menu (hotspot_id)
                channels_table[v]["capture"] = capture_result[i]
             end
          end
-      elseif numResult == 11+hyperlink_skip then
+      elseif numResult == 12+hyperlink_skip then
          if info_on == 0 then
             ColourNote ("yellow", "", "INFO capturing is now ENABLED.")
          else
@@ -1203,7 +1273,7 @@ function right_click_menu (hotspot_id)
          EnableTrigger("raidinfo", 0 == info_on)
          EnableTrigger("claninfo", 0 == info_on)
          info_on = GetTriggerOption("info","enabled")
-      elseif numResult == 12+hyperlink_skip then
+      elseif numResult == 13+hyperlink_skip then
          if global_quest_on == 0 then
             ColourNote ("yellow", "", "Global Quest capturing is now ENABLED.")
          else
@@ -1211,7 +1281,7 @@ function right_click_menu (hotspot_id)
          end
          EnableTrigger("global_quest", 0 == global_quest_on)
          global_quest_on = GetTriggerOption("global_quest","enabled")
-      elseif numResult == 13+hyperlink_skip then
+      elseif numResult == 14+hyperlink_skip then
          if remort_auction_on == 0 then
             ColourNote ("yellow", "", "Remort Auction capturing is now ENABLED.")
          else
@@ -1219,7 +1289,7 @@ function right_click_menu (hotspot_id)
          end
          EnableTrigger("remort_auction", 0 == remort_auction_on)
          remort_auction_on = GetTriggerOption("remort_auction","enabled")
-      elseif numResult == 14+hyperlink_skip then
+      elseif numResult == 15+hyperlink_skip then
          if show_donations == 0 then
             ColourNote ("yellow", "", "Clan donation capturing is now ENABLED.")
          else
@@ -1227,7 +1297,7 @@ function right_click_menu (hotspot_id)
          end
          show_donations = (((0 == show_donations) and 1) or 0)
          SetVariable("show_donations", show_donations)
-      elseif numResult == 15+hyperlink_skip then
+      elseif numResult == 16+hyperlink_skip then
          if warfare_on == 0 then
             ColourNote ("yellow", "", "Warfare capturing is now ENABLED.")
          else
@@ -1257,7 +1327,7 @@ function right_click_menu (hotspot_id)
          end
       end
 
-      if numResult == 16+hyperlink_skip+echo_skip then
+      if numResult == 17+hyperlink_skip+echo_skip then
          log_to_file = (((0 == log_to_file) and 1) or 0)
          SetVariable("log_to_file", log_to_file)
          if log_to_file == 0 then
@@ -1265,7 +1335,7 @@ function right_click_menu (hotspot_id)
          else
             ColourNote ("yellow", "", "Logging to file is now ENABLED.")
          end
-      elseif numResult == 17+hyperlink_skip+echo_skip then
+      elseif numResult == 18+hyperlink_skip+echo_skip then
          log_colour_codes = (((0 == log_colour_codes) and 1) or 0)
          SetVariable("log_colour_codes", log_colour_codes)
          if log_colour_codes == 0 then
@@ -1273,7 +1343,7 @@ function right_click_menu (hotspot_id)
          else
             ColourNote ("yellow", "", "Color codes will be included in the log file.")
          end
-      elseif numResult == 18+hyperlink_skip+echo_skip then
+      elseif numResult == 19+hyperlink_skip+echo_skip then
          log_timestamps = (((0 == log_timestamps) and 1) or 0)
          SetVariable("log_timestamps", log_timestamps)
          if log_timestamps == 0 then
@@ -1281,9 +1351,9 @@ function right_click_menu (hotspot_id)
          else
             ColourNote ("yellow", "", "Timestamps will be included in the log file.")
          end
-      elseif numResult == 19+hyperlink_skip+echo_skip then
-         CallPlugin("462b665ecb569efbf261422f","boostMe", win)
       elseif numResult == 20+hyperlink_skip+echo_skip then
+         CallPlugin("462b665ecb569efbf261422f","boostMe", win)
+      elseif numResult == 21+hyperlink_skip+echo_skip then
          CallPlugin("462b665ecb569efbf261422f","dropMe", win)
       end
       OnPluginSaveState()

--- a/MUSHclient/worlds/plugins/aard_channels_fiendish.xml
+++ b/MUSHclient/worlds/plugins/aard_channels_fiendish.xml
@@ -142,14 +142,25 @@ height = tonumber(GetVariable("WINDOW_HEIGHT")) or default_height
 log_to_file = tonumber(GetVariable("log_to_file")) or 0
 log_colour_codes = tonumber(GetVariable("log_colour_codes")) or 1
 log_timestamps = tonumber(GetVariable("log_timestamps")) or 1
+flat_theme = tonumber(GetVariable("flat_theme")) or 0
 
 -- colours
-WINDOW_BACKGROUND_COLOUR = GetNormalColour(1)
+if flat_theme == 1 then
+   WINDOW_BACKGROUND_COLOUR = 0x1c1c1c
+   WINDOW_BORDER_COLOUR = 0x303030
+   SCROLL_BACKGROUND_COLOUR = 0x1c1c1c
+   SCROLL_BAR_COLOUR = 0x303030
+   SCROLL_DETAIL_COLOUR = 0x111111
+else
+   WINDOW_BACKGROUND_COLOUR = GetNormalColour(1)
+   WINDOW_BORDER_COLOUR = 0xE8E8E8
+   SCROLL_BACKGROUND_COLOUR = 0xE8E8E8
+   SCROLL_BAR_COLOUR = 0x111111
+   SCROLL_DETAIL_COLOUR = 0x000000
+end
+
 WINDOW_TEXT_COLOUR = 0xffffff
-SCROLL_BACKGROUND_COLOUR = 0xE8E8E8
-SCROLL_BAR_COLOUR = 0x111111
-SCROLL_DETAIL_COLOUR = 0x000000
-WINDOW_BORDER_COLOUR = 0xE8E8E8
+
 
 -- offset of text from edge
 TEXT_INSET = 5
@@ -171,6 +182,7 @@ windowinfo = ""
 startx = ""
 starty = ""
 
+
 show_donations = tonumber(GetVariable("show_donations")) or 1
 info_on = tonumber(GetVariable("info_on")) or 0
 global_quest_on = tonumber(GetVariable("global_quest_on")) or 0
@@ -188,6 +200,7 @@ function reset_aard()
    height = default_height
    font_name = default_font_name
    font_size = default_font_size
+   flat_theme = 0
    windowinfo.window_left = default_x
    windowinfo.window_top = default_y
    WindowPosition(win, default_x, default_y, 0, 18)
@@ -335,23 +348,40 @@ function init (firstTime)
 
    -- title rectangle
    header_width = WindowTextWidth(win, win_head_font, "Communication Log")
-   WindowGradient(win, 1, 0, width, TITLE_HEIGHT, WINDOW_BACKGROUND_COLOUR, 0x444444, 2)
+   if flat_theme == 1 then
+      WindowGradient(win, 2, 2, -2, TITLE_HEIGHT, 0x444444, 0x444444, 2)
+   else
+      WindowGradient(win, 1, 0, width, TITLE_HEIGHT, WINDOW_BACKGROUND_COLOUR, 0x444444, 2)
+      WindowLine(win, 0, TITLE_HEIGHT-1, width, TITLE_HEIGHT-1, WINDOW_BORDER_COLOUR, 0 + 0x0200, 1)
+   end
    WindowText(win, win_head_font, "Communication Log", (width-header_width)/2, ((TITLE_HEIGHT-header_font_height)/2)-1, width, TITLE_HEIGHT, 0xEEEEEE, false)
-   WindowLine(win, 0, TITLE_HEIGHT-1, width, TITLE_HEIGHT-1, WINDOW_BORDER_COLOUR, 0 + 0x0200, 1)
-
+   
    -- resize tag
-   WindowRectOp(win, 2, width-SCROLL_BAR_WIDTH, height-SCROLL_BAR_WIDTH, 0, 0, SCROLL_BACKGROUND_COLOUR) -- resizer background
-   WindowLine(win, width-SCROLL_BAR_WIDTH+1, height-2, width-2, height-SCROLL_BAR_WIDTH+1, 0xffffff, 0, 2)
-   WindowLine(win, width-SCROLL_BAR_WIDTH+2, height-2, width-2, height-SCROLL_BAR_WIDTH+2, 0x696969, 0, 1)
-   WindowLine(win, width-SCROLL_BAR_WIDTH+4, height-2, width-2, height-SCROLL_BAR_WIDTH+4, 0xffffff, 0, 2)
-   WindowLine(win, width-SCROLL_BAR_WIDTH+5, height-2, width-2, height-SCROLL_BAR_WIDTH+5, 0x696969, 0, 1)
-   WindowLine(win, width-SCROLL_BAR_WIDTH+7, height-2, width-2, height-SCROLL_BAR_WIDTH+7, 0xffffff, 0, 2)
-   WindowLine(win, width-SCROLL_BAR_WIDTH+8, height-2, width-2, height-SCROLL_BAR_WIDTH+8, 0x696969, 0, 1)
-   WindowLine(win, width-SCROLL_BAR_WIDTH+10, height-2, width-2, height-SCROLL_BAR_WIDTH+10, 0xffffff, 0, 2)
-   WindowLine(win, width-SCROLL_BAR_WIDTH+11, height-2, width-2, height-SCROLL_BAR_WIDTH+11, 0x696969, 0, 1)
+   if flat_theme == 1 then
+      resize_color_1 = 0x303030
+      resize_color_2 = 0x1c1c1c
+   else
+      resize_color_1 = 0xffffff
+      resize_color_2 = 0x696969
+   end
+   WindowRectOp(win, 2, width-SCROLL_BAR_WIDTH, height-SCROLL_BAR_WIDTH, 0, 0, 0x1c1c1c) -- resizer background
+   WindowLine(win, width-SCROLL_BAR_WIDTH+1, height-2, width-2, height-SCROLL_BAR_WIDTH+1, resize_color_1, 0, 2)
+   WindowLine(win, width-SCROLL_BAR_WIDTH+2, height-2, width-2, height-SCROLL_BAR_WIDTH+2, resize_color_2, 0, 1)
+   WindowLine(win, width-SCROLL_BAR_WIDTH+4, height-2, width-2, height-SCROLL_BAR_WIDTH+4, resize_color_1, 0, 2)
+   WindowLine(win, width-SCROLL_BAR_WIDTH+5, height-2, width-2, height-SCROLL_BAR_WIDTH+5, resize_color_2, 0, 1)
+   WindowLine(win, width-SCROLL_BAR_WIDTH+7, height-2, width-2, height-SCROLL_BAR_WIDTH+7, resize_color_1, 0, 2)
+   WindowLine(win, width-SCROLL_BAR_WIDTH+8, height-2, width-2, height-SCROLL_BAR_WIDTH+8, resize_color_2, 0, 1)
+   WindowLine(win, width-SCROLL_BAR_WIDTH+10, height-2, width-2, height-SCROLL_BAR_WIDTH+10, resize_color_1, 0, 2)
+   WindowLine(win, width-SCROLL_BAR_WIDTH+11, height-2, width-2, height-SCROLL_BAR_WIDTH+11, resize_color_2, 0, 1)
 
    -- draw border
-   WindowRectOp(win, 1, 0, 0, 0, 0, WINDOW_BORDER_COLOUR)
+   if flat_theme == 1 then
+      WindowRectOp (win, 1, 0, 0, 0, 0, 0x303030, 15)
+      WindowRectOp (win, 1, 1, 1, -1, -1, 0x444444, 15)
+   else
+      WindowRectOp(win, 1, 0, 0, 0, 0, WINDOW_BORDER_COLOUR)
+      WindowRectOp (win, 1, 1, 1, -1, -1, 0x777777, 15)
+   end 
 
    drawStuff()
 end
@@ -385,6 +415,7 @@ function OnPluginSaveState()
 
    SetVariable("font_name", font_name)
    SetVariable("font_size", font_size)
+   SetVariable("flat_theme", flat_theme)
    SetVariable("date_format", date_format)
    SetVariable("WINDOW_WIDTH", width)
    SetVariable("WINDOW_HEIGHT", height)
@@ -491,7 +522,11 @@ function drawStuff ()
 
    if (keepscrolling == "up") then
       -- draw top scroll button pressed
-      WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), TITLE_HEIGHT, 0, TITLE_HEIGHT+SCROLL_BAR_WIDTH, 10,  15 + 0x800) -- up arrow pushed
+      if flat_theme == 1 then
+         WindowRectOp(win, 4, (width-SCROLL_BAR_WIDTH), TITLE_HEIGHT, 0, TITLE_HEIGHT+SCROLL_BAR_WIDTH, 0x444444, 0x666666) -- up arrow pushed
+      else
+         WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), TITLE_HEIGHT, 0, TITLE_HEIGHT+SCROLL_BAR_WIDTH, 10, 15 + 0x800) -- up arrow pushed
+      end
       points = string.format("%i,%i,%i,%i,%i,%i", (width-SCROLL_BAR_WIDTH)+3, TITLE_HEIGHT+9,(width-SCROLL_BAR_WIDTH)+7, TITLE_HEIGHT+5,(width-SCROLL_BAR_WIDTH)+11, TITLE_HEIGHT+9)
       WindowPolygon(win, points,
          0x000000, 0, 1, -- pen (solid, width 1)
@@ -500,7 +535,11 @@ function drawStuff ()
          false) -- alt fill
    else
       -- draw top scroll button unpressed
-      WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), TITLE_HEIGHT, width, TITLE_HEIGHT+SCROLL_BAR_WIDTH, 5, 15 + 0x800)
+      if flat_theme == 1 then
+         WindowRectOp(win, 4, (width-SCROLL_BAR_WIDTH), TITLE_HEIGHT, width, TITLE_HEIGHT+SCROLL_BAR_WIDTH, 0x303030 , 0x444444)
+      else
+         WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), TITLE_HEIGHT, width, TITLE_HEIGHT+SCROLL_BAR_WIDTH, 5, 15 + 0x800)
+      end
       points = string.format("%i,%i,%i,%i,%i,%i", (width-SCROLL_BAR_WIDTH)+3, TITLE_HEIGHT+9,(width-SCROLL_BAR_WIDTH)+7, TITLE_HEIGHT+5,(width-SCROLL_BAR_WIDTH)+11, TITLE_HEIGHT+9)
       WindowPolygon(win, points,
          0x000000, 0, 1,   -- pen (solid, width 1)
@@ -511,7 +550,11 @@ function drawStuff ()
 
    if (keepscrolling == "down") then
       -- draw bottom scroll button pressed
-      WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), height-(SCROLL_BAR_WIDTH*2), 0, height-SCROLL_BAR_WIDTH-1, 10,  15 + 0x800)
+      if flat_theme == 1 then
+         WindowRectOp(win, 4, (width-SCROLL_BAR_WIDTH), height-(SCROLL_BAR_WIDTH*2), 0, height-SCROLL_BAR_WIDTH-1, 0x444444,  0x666666)
+      else
+         WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), height-(SCROLL_BAR_WIDTH*2), 0, height-SCROLL_BAR_WIDTH-1, 10, 15 + 0x800)
+      end
       points = string.format("%i,%i,%i,%i,%i,%i", (width-SCROLL_BAR_WIDTH)+3, (height-SCROLL_BAR_WIDTH)-11,(width-SCROLL_BAR_WIDTH)+7, (height-SCROLL_BAR_WIDTH)-7, (width-SCROLL_BAR_WIDTH)+11,(height-SCROLL_BAR_WIDTH)-11)
       WindowPolygon(win, points,
          0x000000, 0, 1, -- pen (solid, width 1)
@@ -520,7 +563,11 @@ function drawStuff ()
          false) -- alt fill
    else
       -- draw bottom scroll button unpressed
-      WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), height-(SCROLL_BAR_WIDTH*2), width, height-SCROLL_BAR_WIDTH, 5,  15 + 0x800)
+      if flat_theme == 1 then
+         WindowRectOp(win, 4, (width-SCROLL_BAR_WIDTH), height-(SCROLL_BAR_WIDTH*2), width, height-SCROLL_BAR_WIDTH, 0x303030, 0x444444)
+      else
+         WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), height-(SCROLL_BAR_WIDTH*2), 0, height-SCROLL_BAR_WIDTH-1, 5, 15 + 0x800)
+      end
       points = string.format("%i,%i,%i,%i,%i,%i", (width-SCROLL_BAR_WIDTH)+3, (height-SCROLL_BAR_WIDTH)-11,(width-SCROLL_BAR_WIDTH)+7, (height-SCROLL_BAR_WIDTH)-7, (width-SCROLL_BAR_WIDTH)+11,(height-SCROLL_BAR_WIDTH)-11)
       WindowPolygon(win, points,
          0x000000, 0, 1,   -- pen (solid, width 1)
@@ -548,7 +595,11 @@ function drawStuff ()
       WindowAddHotspot(win, "scroller", (width-SCROLL_BAR_WIDTH), barPos, width, barPos+barSize, "MouseOver", "CancelMouseOver", "MouseDown", "CancelMouseDown", "MouseUp", "", 1, 0)
       WindowDragHandler(win, "scroller", "ScrollerMoveCallback", "ScrollerReleaseCallback", 0)
    end
-   WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), barPos, width, barPos+barSize, 5, 15 + 0x800) -- scrollbar position indicator
+   if flat_theme == 1 then
+      WindowRectOp(win, 4, (width-SCROLL_BAR_WIDTH), barPos, width, barPos+barSize, 0x444444, 0x333333) -- scrollbar position indicator
+   else
+      WindowRectOp(win, 5, (width-SCROLL_BAR_WIDTH), barPos, width, barPos+barSize, 5, 15 + 0x800) -- scrollbar position indicator
+   end
 
    -- reset hyperlinks if the text moves
    for k,v in pairs(hyperlinks) do
@@ -1103,7 +1154,7 @@ function right_click_menu (hotspot_id)
       menustring = menustring.."Go to URL: "..hyperlinks[hotspot_id].."|Copy URL to Clipboard|-|"
       url = hyperlinks[hotspot_id]
    end
-   menustring = menustring.."Copy Selected Without Colors|Copy Selected|Copy All|-|Change Font"
+   menustring = menustring.."Copy Selected Without Colors|Copy Selected|Copy All|-|Change Font|"..((flat_theme==1 and "+") or "").."Flat Theme"
    menustring = menustring .. "|>Timestamp|"..((date_format=="" and "+") or "").."No Timestamps|"..((date_format=="[%d %b %H:%M:%S] " and "+") or "").."30 Aug 13:29:49|"..((date_format=="[%d %b %I:%M:%S%p] " and "+") or "").."30 Aug 01:20:12PM|"..((date_format=="[%H:%M:%S] " and "+") or "").."13:29:08|"..((date_format=="[%I:%M:%S%p] " and "+") or "").."1:22:06 PM|<"
 
    menustring = menustring .. "|Customize Channels"
@@ -1164,21 +1215,40 @@ function right_click_menu (hotspot_id)
             OnPluginInstall()
          end
       elseif numResult == 5+hyperlink_skip then
+         if flat_theme == 0 then
+            ColourNote ("yellow", "", "Flat Theme for communication window is ENABLED.")
+            WINDOW_BACKGROUND_COLOUR = 0x1c1c1c
+            WINDOW_BORDER_COLOUR = 0x303030
+            SCROLL_BACKGROUND_COLOUR = 0x303030
+            SCROLL_BAR_COLOUR = 0x1c1c1c
+            SCROLL_DETAIL_COLOUR = 0x111111
+         else  
+            ColourNote ("yellow", "", "Flat Theme for communication window is DISABLED.")
+            WINDOW_BACKGROUND_COLOUR = GetNormalColour(1)
+            WINDOW_BORDER_COLOUR = 0xE8E8E8
+            SCROLL_BACKGROUND_COLOUR = 0xE8E8E8
+            SCROLL_BAR_COLOUR = 0x111111
+            SCROLL_DETAIL_COLOUR = 0x000000
+         end
+         flat_theme = (((0 == flat_theme) and 1) or 0)
+         SetVariable("flat_theme", flat_theme)
+         OnPluginInstall()
+      elseif numResult == 6+hyperlink_skip then
          date_format = ""
          ColourNote ("yellow", "", "Timestamps in communication window DISABLED.")
-      elseif numResult == 6+hyperlink_skip then
+      elseif numResult == 7+hyperlink_skip then
          date_format = "[%d %b %H:%M:%S] "
          ColourNote ("yellow", "", "Timestamps in communication window ENABLED using format like '30 Aug 13:29:49'.")
-      elseif numResult == 7+hyperlink_skip then
+      elseif numResult == 8+hyperlink_skip then
          date_format = "[%d %b %I:%M:%S%p] "
          ColourNote ("yellow", "", "Timestamps in communication window ENABLED using format like '30 Aug 01:20:12PM'.")
-      elseif numResult == 8+hyperlink_skip then
+      elseif numResult == 9+hyperlink_skip then
          date_format = "[%H:%M:%S] "
          ColourNote ("yellow", "", "Timestamps in communication window ENABLED using format like '13:29:08'.")
-      elseif numResult == 9+hyperlink_skip then
+      elseif numResult == 10+hyperlink_skip then
          date_format = "[%I:%M:%S%p] "
          ColourNote ("yellow", "", "Timestamps in communication window ENABLED using format like '1:22:06 PM'.")
-      elseif numResult == 10+hyperlink_skip then
+      elseif numResult == 11+hyperlink_skip then
          local tbl = {}
          local defaults = {}
          local i = 1
@@ -1193,7 +1263,7 @@ function right_click_menu (hotspot_id)
                channels_table[v]["capture"] = capture_result[i]
             end
          end
-      elseif numResult == 11+hyperlink_skip then
+      elseif numResult == 12+hyperlink_skip then
          if info_on == 0 then
             ColourNote ("yellow", "", "INFO capturing is now ENABLED.")
          else
@@ -1203,7 +1273,7 @@ function right_click_menu (hotspot_id)
          EnableTrigger("raidinfo", 0 == info_on)
          EnableTrigger("claninfo", 0 == info_on)
          info_on = GetTriggerOption("info","enabled")
-      elseif numResult == 12+hyperlink_skip then
+      elseif numResult == 13+hyperlink_skip then
          if global_quest_on == 0 then
             ColourNote ("yellow", "", "Global Quest capturing is now ENABLED.")
          else
@@ -1211,7 +1281,7 @@ function right_click_menu (hotspot_id)
          end
          EnableTrigger("global_quest", 0 == global_quest_on)
          global_quest_on = GetTriggerOption("global_quest","enabled")
-      elseif numResult == 13+hyperlink_skip then
+      elseif numResult == 14+hyperlink_skip then
          if remort_auction_on == 0 then
             ColourNote ("yellow", "", "Remort Auction capturing is now ENABLED.")
          else
@@ -1219,7 +1289,7 @@ function right_click_menu (hotspot_id)
          end
          EnableTrigger("remort_auction", 0 == remort_auction_on)
          remort_auction_on = GetTriggerOption("remort_auction","enabled")
-      elseif numResult == 14+hyperlink_skip then
+      elseif numResult == 15+hyperlink_skip then
          if show_donations == 0 then
             ColourNote ("yellow", "", "Clan donation capturing is now ENABLED.")
          else
@@ -1227,7 +1297,7 @@ function right_click_menu (hotspot_id)
          end
          show_donations = (((0 == show_donations) and 1) or 0)
          SetVariable("show_donations", show_donations)
-      elseif numResult == 15+hyperlink_skip then
+      elseif numResult == 16+hyperlink_skip then
          if warfare_on == 0 then
             ColourNote ("yellow", "", "Warfare capturing is now ENABLED.")
          else
@@ -1257,7 +1327,7 @@ function right_click_menu (hotspot_id)
          end
       end
 
-      if numResult == 16+hyperlink_skip+echo_skip then
+      if numResult == 17+hyperlink_skip+echo_skip then
          log_to_file = (((0 == log_to_file) and 1) or 0)
          SetVariable("log_to_file", log_to_file)
          if log_to_file == 0 then
@@ -1265,7 +1335,7 @@ function right_click_menu (hotspot_id)
          else
             ColourNote ("yellow", "", "Logging to file is now ENABLED.")
          end
-      elseif numResult == 17+hyperlink_skip+echo_skip then
+      elseif numResult == 18+hyperlink_skip+echo_skip then
          log_colour_codes = (((0 == log_colour_codes) and 1) or 0)
          SetVariable("log_colour_codes", log_colour_codes)
          if log_colour_codes == 0 then
@@ -1273,7 +1343,7 @@ function right_click_menu (hotspot_id)
          else
             ColourNote ("yellow", "", "Color codes will be included in the log file.")
          end
-      elseif numResult == 18+hyperlink_skip+echo_skip then
+      elseif numResult == 19+hyperlink_skip+echo_skip then
          log_timestamps = (((0 == log_timestamps) and 1) or 0)
          SetVariable("log_timestamps", log_timestamps)
          if log_timestamps == 0 then
@@ -1281,9 +1351,9 @@ function right_click_menu (hotspot_id)
          else
             ColourNote ("yellow", "", "Timestamps will be included in the log file.")
          end
-      elseif numResult == 19+hyperlink_skip+echo_skip then
-         CallPlugin("462b665ecb569efbf261422f","boostMe", win)
       elseif numResult == 20+hyperlink_skip+echo_skip then
+         CallPlugin("462b665ecb569efbf261422f","boostMe", win)
+      elseif numResult == 21+hyperlink_skip+echo_skip then
          CallPlugin("462b665ecb569efbf261422f","dropMe", win)
       end
       OnPluginSaveState()

--- a/MUSHclient/worlds/plugins/aard_group_monitor_gmcp.xml
+++ b/MUSHclient/worlds/plugins/aard_group_monitor_gmcp.xml
@@ -142,6 +142,8 @@ require "gmcphelper"
 require "copytable"
 require "serialize"
 
+flat_theme = tonumber (GetVariable("flat_theme")) or 0
+
 if flat_theme == 1 then
    background_colour = 0x1c1c1c
    border_color = 0x303030

--- a/MUSHclient/worlds/plugins/aard_group_monitor_gmcp.xml
+++ b/MUSHclient/worlds/plugins/aard_group_monitor_gmcp.xml
@@ -142,7 +142,20 @@ require "gmcphelper"
 require "copytable"
 require "serialize"
 
-background_colour = tonumber (GetVariable ("background_colour")) or 0x000000
+flat_theme = tonumber (GetVariable("flat_theme")) or 0
+
+if flat_theme == 1 then
+   background_colour = 0x1c1c1c
+   border_color = 0x303030
+   title_gradient_col1 = 0x303030
+   title_gradient_col2 = 0x303030
+else
+   background_colour = 0x000000
+   border_color = 0xdddddd
+   title_gradient_col1 = 0x000000
+   title_gradient_col2 = 0x444444
+end
+
 title_colour = tonumber (GetVariable ("title_colour")) or 0x292929
 default_x = 868
 default_y = 336
@@ -160,9 +173,6 @@ overlay_numbers = tonumber (GetVariable("overlay_numbers")) or 0
 GAP = 3
 font_size = 0
 font_name = ""
-border_color = 0xdddddd
-title_gradient_col1 = 0x000000
-title_gradient_col2 = 0x444444
 group_members = {}
 group_info = {}
 
@@ -278,7 +288,9 @@ function DisplayGroupPage()
 
    -- title rectangle
    WindowGradient(win, 2, 2, -2, title_height, title_gradient_col1, title_gradient_col2, 2)
-   WindowLine(win, 0, title_height, width, title_height, 0xeeeeee, 0, 1)
+   if flat_theme == 0 then
+      WindowLine(win, 0, title_height, width, title_height, 0xeeeeee, 0, 1)
+   end
 
    if not group_built then
       if next(invitations) == nil then
@@ -439,17 +451,26 @@ function DisplayGroupPage()
 
    -- draw edge frame.
    WindowRectOp (win, 1, 0, 0, 0, 0, border_color, 15)
-   WindowRectOp (win, 1, 1, 1, -1, -1, 0x777777, 15)
+   if flat_theme == 0 then
+      WindowRectOp (win, 1, 1, 1, -1, -1, 0x444444, 15)
+   end
 
    -- draw the resize widget bottom right corner.
-   WindowLine(win, width-3, height-2, width-2, height-3, 0xffffff, 0, 2)
-   WindowLine(win, width-4, height-2, width-2, height-4, 0x696969, 0, 1)
-   WindowLine(win, width-6, height-2, width-2, height-6, 0xffffff, 0, 2)
-   WindowLine(win, width-7, height-2, width-2, height-7, 0x696969, 0, 1)
-   WindowLine(win, width-9, height-2, width-2, height-9, 0xffffff, 0, 2)
-   WindowLine(win, width-10, height-2, width-2, height-10, 0x696969, 0, 1)
-   WindowLine(win, width-12, height-2, width-2, height-12, 0xffffff, 0, 2)
-   WindowLine(win, width-13, height-2, width-2, height-13, 0x696969, 0, 1)
+   if flat_theme == 1 then
+      resize_col_1 = 0x303030
+      resize_col_2 = 0x1c1c1c
+   else
+      resize_col_1 = 0xffffff
+      resize_col_2 = 0x696969
+   end
+   WindowLine(win, width-3, height-2, width-2, height-3, resize_col_1, 0, 2)
+   WindowLine(win, width-4, height-2, width-2, height-4, resize_col_2, 0, 1)
+   WindowLine(win, width-6, height-2, width-2, height-6, resize_col_1, 0, 2)
+   WindowLine(win, width-7, height-2, width-2, height-7, resize_col_2, 0, 1)
+   WindowLine(win, width-9, height-2, width-2, height-9, resize_col_1, 0, 2)
+   WindowLine(win, width-10, height-2, width-2, height-10, resize_col_2, 0, 1)
+   WindowLine(win, width-12, height-2, width-2, height-12, resize_col_1, 0, 2)
+   WindowLine(win, width-13, height-2, width-2, height-13, resize_col_2, 0, 1)
 
    BroadcastPlugin (999, "repaint")
 
@@ -469,7 +490,7 @@ end
 
 function right_click_menu ()
 
-   menustring ="!Change Font|>Show Players|"..((show_self==1 and "+") or "").."Include Self|All Others|No Others|-|"
+   menustring ="!Change Font|"..((flat_theme==1 and "+") or "").."Flat Theme|>Show Players|"..((show_self==1 and "+") or "").."Include Self|All Others|No Others|-|"
    local member_count = 0
    local member_names = {}
    if full_group_data and full_group_data.members and char_data and char_data.name then
@@ -497,6 +518,17 @@ function right_click_menu ()
             font_size = wanted_font.size
          end
       elseif numResult == 2 then
+         if flat_theme == 0 then
+            ColourNote ("yellow", "", "Flat Theme for group monitor is ENABLED.")
+            background_colour = 0x1c1c1c
+            border_color = 0x303030
+         else  
+            ColourNote ("yellow", "", "Flat Theme for group monitor is DISABLED.")
+            background_colour = 0x000000 
+            border_color = 0xcccccc 
+         end
+         flat_theme = (((0 == flat_theme) and 1) or 0)
+      elseif numResult == 3 then
          -- show/hide self
          show_self = (((show_self == 0) and 1) or 0)
          if (show_self == 0) then
@@ -504,17 +536,17 @@ function right_click_menu ()
          else
             ColourNote("yellow", "", "You will now see your own status in the group monitor.")
          end
-      elseif numResult == 3 then
+      elseif numResult == 4 then
          -- remove all from the hidden list
          hidden_members = {}
-      elseif numResult == 4 then
+      elseif numResult == 5 then
          -- add all to the hidden list
          hideAllMembers()
-      elseif numResult >= 5 and numResult <= member_count+4 then
+      elseif numResult >= 7 and numResult <= member_count+5 then
          -- add/remove members in the hidden list
          local adjustedNumResult = numResult - 4
          hidden_members[member_names[adjustedNumResult]] = (((hidden_members[member_names[adjustedNumResult]]== nil) and true) or nil)
-      elseif numResult >= member_count+5 and numResult <= member_count+12 then
+      elseif numResult >= member_count+6 and numResult <= member_count+13 then
          -- change color settings
          local adjustedNumResult = numResult-member_count-4
          local colourIndex = 2
@@ -525,7 +557,7 @@ function right_click_menu ()
          if newcolour ~= -1 then
             colorVals[barIndex[math.ceil(adjustedNumResult/2)]][colourIndex] = newcolour
          end
-      elseif numResult == member_count+13 then
+      elseif numResult == member_count+14 then
          -- show/hide HP info
          show_hp = (((show_hp == 0) and 1) or 0)
          if (show_hp == 0) then
@@ -533,7 +565,7 @@ function right_click_menu ()
          else
             ColourNote("yellow", "", "You will now see HP info in the group monitor.")
          end
-      elseif numResult == member_count+14   then
+      elseif numResult == member_count+15   then
          -- show/hide MANA info
          show_mn = (((show_mn == 0) and 1) or 0)
          if (show_mn == 0) then
@@ -541,7 +573,7 @@ function right_click_menu ()
          else
             ColourNote("yellow", "", "You will now see MN info in the group monitor.")
          end
-      elseif numResult == member_count+15 then
+      elseif numResult == member_count+16 then
          -- show/hide MOVES info
          show_mv = (((show_mv == 0) and 1) or 0)
          if (show_mv == 0) then
@@ -549,15 +581,15 @@ function right_click_menu ()
          else
             ColourNote("yellow", "", "You will now see MV info in the group monitor.")
          end
-      elseif numResult == member_count+16 then
+      elseif numResult == member_count+17 then
          -- use flat/shaded gauges
          flat_gauges = (((flat_gauges == 0) and 1) or 0)
-      elseif numResult == member_count+17 then
+      elseif numResult == member_count+18 then
          -- toggle overlay numbers on top of gauges
          overlay_numbers = (((overlay_numbers == 0) and 1) or 0)
-      elseif numResult == member_count+18 then
-         thresh1active = (((thresh1active == 0) and 1) or 0)
       elseif numResult == member_count+19 then
+         thresh1active = (((thresh1active == 0) and 1) or 0)
+      elseif numResult == member_count+20 then
          local perc = utils.inputbox( "I want the HP bars to change color when they drop below this percent...\n(enter a whole number between 1 and 100)", "Group Monitor HP Threshold #1", thresh1percent, nil, nil, {validate=validate_percent})
          if perc then
             if string.sub(perc, -1) == "%" then
@@ -565,14 +597,14 @@ function right_click_menu ()
             end
             thresh1percent = tonumber(perc)
          end
-      elseif numResult == member_count+20 then
+      elseif numResult == member_count+21 then
          local newColor = PickColour (thresh1color)
          if newcolor ~= -1 then
             thresh1color = newColor
          end
-      elseif numResult == member_count+21 then
-         thresh2active = (((thresh2active == 0) and 1) or 0)
       elseif numResult == member_count+22 then
+         thresh2active = (((thresh2active == 0) and 1) or 0)
+      elseif numResult == member_count+23 then
          local perc = utils.inputbox( "I want the HP bars to change color when they drop below this percent...\n(enter a whole number between 1 and 100)", "Group Monitor HP Threshold #2", thresh2percent, nil, nil, {validate=validate_percent})
          if perc then
             if string.sub(perc, -1) == "%" then
@@ -580,24 +612,25 @@ function right_click_menu ()
             end
             thresh2percent = tonumber(perc)
          end
-      elseif numResult == member_count+23 then
+      elseif numResult == member_count+24 then
          local newColor = PickColour (thresh2color)
          if newcolor ~= -1 then
             thresh2color = newColor
          end
-      elseif numResult == member_count+24 then
+      elseif numResult == member_count+25 then
          -- bring to front
          CallPlugin("462b665ecb569efbf261422f","boostMe", win)
-      elseif numResult == member_count+25 then
+      elseif numResult == member_count+26 then
          -- send to back
          CallPlugin("462b665ecb569efbf261422f","dropMe", win)
-      elseif numResult == member_count+26 then
+      elseif numResult == member_count+27 then
          -- reset
          font_name        = default_font_name
          font_size        = default_font_size
          height           = default_height
          width            = default_width
          show_coords      = 0
+         flat_theme       = 0
       end -- if
 
       RemoveMembersFromGroupDisplay()
@@ -756,6 +789,7 @@ function OnPluginSaveState ()
    SetVariable ("height", height)
    SetVariable ("font_name", font_name)
    SetVariable ("font_size", font_size)
+   SetVariable ("flat_theme", flat_theme)
    SetVariable ("show_self", show_self)
    SetVariable ("show_hp", show_hp)
    SetVariable ("show_mn", show_mn)
@@ -837,6 +871,7 @@ function OnPluginInstall()
 
    font_name = GetVariable("font_name") or default_font_name
    font_size = tonumber(GetVariable("font_size")) or default_font_size
+   flat_theme = tonumber(GetVariable("flat_theme")) or 0
 
    --- Load the fonts into the temp window.
    WindowFont (win, font_id, font_name, font_size, false, false, false, false) -- normal font

--- a/MUSHclient/worlds/plugins/aard_group_monitor_gmcp.xml
+++ b/MUSHclient/worlds/plugins/aard_group_monitor_gmcp.xml
@@ -142,7 +142,18 @@ require "gmcphelper"
 require "copytable"
 require "serialize"
 
-background_colour = tonumber (GetVariable ("background_colour")) or 0x000000
+if flat_theme == 1 then
+   background_colour = 0x1c1c1c
+   border_color = 0x303030
+   title_gradient_col1 = 0x303030
+   title_gradient_col2 = 0x303030
+else
+   background_colour = 0x000000
+   border_color = 0xdddddd
+   title_gradient_col1 = 0x000000
+   title_gradient_col2 = 0x444444
+end
+
 title_colour = tonumber (GetVariable ("title_colour")) or 0x292929
 default_x = 868
 default_y = 336
@@ -160,9 +171,6 @@ overlay_numbers = tonumber (GetVariable("overlay_numbers")) or 0
 GAP = 3
 font_size = 0
 font_name = ""
-border_color = 0xdddddd
-title_gradient_col1 = 0x000000
-title_gradient_col2 = 0x444444
 group_members = {}
 group_info = {}
 
@@ -278,7 +286,9 @@ function DisplayGroupPage()
 
    -- title rectangle
    WindowGradient(win, 2, 2, -2, title_height, title_gradient_col1, title_gradient_col2, 2)
-   WindowLine(win, 0, title_height, width, title_height, 0xeeeeee, 0, 1)
+   if flat_theme == 0 then
+      WindowLine(win, 0, title_height, width, title_height, 0xeeeeee, 0, 1)
+   end
 
    if not group_built then
       if next(invitations) == nil then
@@ -439,17 +449,26 @@ function DisplayGroupPage()
 
    -- draw edge frame.
    WindowRectOp (win, 1, 0, 0, 0, 0, border_color, 15)
-   WindowRectOp (win, 1, 1, 1, -1, -1, 0x777777, 15)
+   if flat_theme == 0 then
+      WindowRectOp (win, 1, 1, 1, -1, -1, 0x444444, 15)
+   end
 
    -- draw the resize widget bottom right corner.
-   WindowLine(win, width-3, height-2, width-2, height-3, 0xffffff, 0, 2)
-   WindowLine(win, width-4, height-2, width-2, height-4, 0x696969, 0, 1)
-   WindowLine(win, width-6, height-2, width-2, height-6, 0xffffff, 0, 2)
-   WindowLine(win, width-7, height-2, width-2, height-7, 0x696969, 0, 1)
-   WindowLine(win, width-9, height-2, width-2, height-9, 0xffffff, 0, 2)
-   WindowLine(win, width-10, height-2, width-2, height-10, 0x696969, 0, 1)
-   WindowLine(win, width-12, height-2, width-2, height-12, 0xffffff, 0, 2)
-   WindowLine(win, width-13, height-2, width-2, height-13, 0x696969, 0, 1)
+   if flat_theme == 1 then
+      resize_col_1 = 0x303030
+      resize_col_2 = 0x1c1c1c
+   else
+      resize_col_1 = 0xffffff
+      resize_col_2 = 0x696969
+   end
+   WindowLine(win, width-3, height-2, width-2, height-3, resize_col_1, 0, 2)
+   WindowLine(win, width-4, height-2, width-2, height-4, resize_col_2, 0, 1)
+   WindowLine(win, width-6, height-2, width-2, height-6, resize_col_1, 0, 2)
+   WindowLine(win, width-7, height-2, width-2, height-7, resize_col_2, 0, 1)
+   WindowLine(win, width-9, height-2, width-2, height-9, resize_col_1, 0, 2)
+   WindowLine(win, width-10, height-2, width-2, height-10, resize_col_2, 0, 1)
+   WindowLine(win, width-12, height-2, width-2, height-12, resize_col_1, 0, 2)
+   WindowLine(win, width-13, height-2, width-2, height-13, resize_col_2, 0, 1)
 
    BroadcastPlugin (999, "repaint")
 
@@ -469,7 +488,7 @@ end
 
 function right_click_menu ()
 
-   menustring ="!Change Font|>Show Players|"..((show_self==1 and "+") or "").."Include Self|All Others|No Others|-|"
+   menustring ="!Change Font|"..((flat_theme==1 and "+") or "").."Flat Theme|>Show Players|"..((show_self==1 and "+") or "").."Include Self|All Others|No Others|-|"
    local member_count = 0
    local member_names = {}
    if full_group_data and full_group_data.members and char_data and char_data.name then
@@ -497,6 +516,17 @@ function right_click_menu ()
             font_size = wanted_font.size
          end
       elseif numResult == 2 then
+         if flat_theme == 0 then
+            ColourNote ("yellow", "", "Flat Theme for group monitor is ENABLED.")
+            background_colour = 0x1c1c1c
+            border_color = 0x303030
+         else  
+            ColourNote ("yellow", "", "Flat Theme for group monitor is DISABLED.")
+            background_colour = 0x000000 
+            border_color = 0xcccccc 
+         end
+         flat_theme = (((0 == flat_theme) and 1) or 0)
+      elseif numResult == 3 then
          -- show/hide self
          show_self = (((show_self == 0) and 1) or 0)
          if (show_self == 0) then
@@ -504,17 +534,17 @@ function right_click_menu ()
          else
             ColourNote("yellow", "", "You will now see your own status in the group monitor.")
          end
-      elseif numResult == 3 then
+      elseif numResult == 4 then
          -- remove all from the hidden list
          hidden_members = {}
-      elseif numResult == 4 then
+      elseif numResult == 5 then
          -- add all to the hidden list
          hideAllMembers()
-      elseif numResult >= 5 and numResult <= member_count+4 then
+      elseif numResult >= 7 and numResult <= member_count+5 then
          -- add/remove members in the hidden list
          local adjustedNumResult = numResult - 4
          hidden_members[member_names[adjustedNumResult]] = (((hidden_members[member_names[adjustedNumResult]]== nil) and true) or nil)
-      elseif numResult >= member_count+5 and numResult <= member_count+12 then
+      elseif numResult >= member_count+6 and numResult <= member_count+13 then
          -- change color settings
          local adjustedNumResult = numResult-member_count-4
          local colourIndex = 2
@@ -525,7 +555,7 @@ function right_click_menu ()
          if newcolour ~= -1 then
             colorVals[barIndex[math.ceil(adjustedNumResult/2)]][colourIndex] = newcolour
          end
-      elseif numResult == member_count+13 then
+      elseif numResult == member_count+14 then
          -- show/hide HP info
          show_hp = (((show_hp == 0) and 1) or 0)
          if (show_hp == 0) then
@@ -533,7 +563,7 @@ function right_click_menu ()
          else
             ColourNote("yellow", "", "You will now see HP info in the group monitor.")
          end
-      elseif numResult == member_count+14   then
+      elseif numResult == member_count+15   then
          -- show/hide MANA info
          show_mn = (((show_mn == 0) and 1) or 0)
          if (show_mn == 0) then
@@ -541,7 +571,7 @@ function right_click_menu ()
          else
             ColourNote("yellow", "", "You will now see MN info in the group monitor.")
          end
-      elseif numResult == member_count+15 then
+      elseif numResult == member_count+16 then
          -- show/hide MOVES info
          show_mv = (((show_mv == 0) and 1) or 0)
          if (show_mv == 0) then
@@ -549,15 +579,15 @@ function right_click_menu ()
          else
             ColourNote("yellow", "", "You will now see MV info in the group monitor.")
          end
-      elseif numResult == member_count+16 then
+      elseif numResult == member_count+17 then
          -- use flat/shaded gauges
          flat_gauges = (((flat_gauges == 0) and 1) or 0)
-      elseif numResult == member_count+17 then
+      elseif numResult == member_count+18 then
          -- toggle overlay numbers on top of gauges
          overlay_numbers = (((overlay_numbers == 0) and 1) or 0)
-      elseif numResult == member_count+18 then
-         thresh1active = (((thresh1active == 0) and 1) or 0)
       elseif numResult == member_count+19 then
+         thresh1active = (((thresh1active == 0) and 1) or 0)
+      elseif numResult == member_count+20 then
          local perc = utils.inputbox( "I want the HP bars to change color when they drop below this percent...\n(enter a whole number between 1 and 100)", "Group Monitor HP Threshold #1", thresh1percent, nil, nil, {validate=validate_percent})
          if perc then
             if string.sub(perc, -1) == "%" then
@@ -565,14 +595,14 @@ function right_click_menu ()
             end
             thresh1percent = tonumber(perc)
          end
-      elseif numResult == member_count+20 then
+      elseif numResult == member_count+21 then
          local newColor = PickColour (thresh1color)
          if newcolor ~= -1 then
             thresh1color = newColor
          end
-      elseif numResult == member_count+21 then
-         thresh2active = (((thresh2active == 0) and 1) or 0)
       elseif numResult == member_count+22 then
+         thresh2active = (((thresh2active == 0) and 1) or 0)
+      elseif numResult == member_count+23 then
          local perc = utils.inputbox( "I want the HP bars to change color when they drop below this percent...\n(enter a whole number between 1 and 100)", "Group Monitor HP Threshold #2", thresh2percent, nil, nil, {validate=validate_percent})
          if perc then
             if string.sub(perc, -1) == "%" then
@@ -580,24 +610,25 @@ function right_click_menu ()
             end
             thresh2percent = tonumber(perc)
          end
-      elseif numResult == member_count+23 then
+      elseif numResult == member_count+24 then
          local newColor = PickColour (thresh2color)
          if newcolor ~= -1 then
             thresh2color = newColor
          end
-      elseif numResult == member_count+24 then
+      elseif numResult == member_count+25 then
          -- bring to front
          CallPlugin("462b665ecb569efbf261422f","boostMe", win)
-      elseif numResult == member_count+25 then
+      elseif numResult == member_count+26 then
          -- send to back
          CallPlugin("462b665ecb569efbf261422f","dropMe", win)
-      elseif numResult == member_count+26 then
+      elseif numResult == member_count+27 then
          -- reset
          font_name        = default_font_name
          font_size        = default_font_size
          height           = default_height
          width            = default_width
          show_coords      = 0
+         flat_theme       = 0
       end -- if
 
       RemoveMembersFromGroupDisplay()
@@ -756,6 +787,7 @@ function OnPluginSaveState ()
    SetVariable ("height", height)
    SetVariable ("font_name", font_name)
    SetVariable ("font_size", font_size)
+   SetVariable ("flat_theme", flat_theme)
    SetVariable ("show_self", show_self)
    SetVariable ("show_hp", show_hp)
    SetVariable ("show_mn", show_mn)
@@ -837,6 +869,7 @@ function OnPluginInstall()
 
    font_name = GetVariable("font_name") or default_font_name
    font_size = tonumber(GetVariable("font_size")) or default_font_size
+   flat_theme = tonumber(GetVariable("flat_theme")) or 0
 
    --- Load the fonts into the temp window.
    WindowFont (win, font_id, font_name, font_size, false, false, false, false) -- normal font

--- a/MUSHclient/worlds/plugins/aard_health_bars_gmcp.xml
+++ b/MUSHclient/worlds/plugins/aard_health_bars_gmcp.xml
@@ -44,8 +44,6 @@ require "gauge"
 require "gmcphelper"
 require "serialize"
 
-background_colour     = 0x000000
-border_color          = 0xcccccc
 default_width         = 1137
 default_x             = 0
 default_y             = 552
@@ -68,6 +66,15 @@ thresh1percent = tonumber (GetVariable("thresh1percent")) or 40
 thresh2percent = tonumber (GetVariable("thresh2percent")) or 20
 thresh1color = tonumber (GetVariable("thresh1color")) or 0x00ffff
 thresh2color = tonumber (GetVariable("thresh2color")) or 0x0000ff
+
+flat_theme = tonumber (GetVariable("flat_theme")) or 0
+if flat_theme == 1 then
+   background_colour = 0x1c1c1c
+   border_color = 0x303030
+else  
+   background_colour = 0x000000 
+   border_color = 0xcccccc 
+end
 
 -- Variables not saved.
 startx     = ""
@@ -97,6 +104,7 @@ function reset_aard()
    width = default_width
    font_name = default_font_name
    font_size = default_font_size
+   flat_theme = 0
    windowinfo.window_left = default_x
    windowinfo.window_top = default_y
    WindowPosition(win, default_x, default_y, 0, 18)
@@ -320,17 +328,28 @@ function DisplayStatsPage()
 
    -- draw edge frame.
    WindowRectOp (win, 1, 0, 0, 0, 0, border_color, 15)
-   WindowRectOp (win, 1, 1, 1, -1, -1, 0x777777, 15)
+   if flat_theme == 1 then
+      --WindowRectOp (win, 1, 1, 1, -1, -1, 0x444444, 15)
+   else
+      WindowRectOp (win, 1, 1, 1, -1, -1, 0x777777, 15)
+   end
 
    -- draw the resize widget bottom right corner.
-   WindowLine(win, effectiveWidth-3, height-2, effectiveWidth-2, height-3, 0xffffff, 0, 2)
-   WindowLine(win, effectiveWidth-4, height-2, effectiveWidth-2, height-4, 0x696969, 0, 1)
-   WindowLine(win, effectiveWidth-6, height-2, effectiveWidth-2, height-6, 0xffffff, 0, 2)
-   WindowLine(win, effectiveWidth-7, height-2, effectiveWidth-2, height-7, 0x696969, 0, 1)
-   WindowLine(win, effectiveWidth-9, height-2, effectiveWidth-2, height-9, 0xffffff, 0, 2)
-   WindowLine(win, effectiveWidth-10, height-2, effectiveWidth-2, height-10, 0x696969, 0, 1)
-   WindowLine(win, effectiveWidth-12, height-2, effectiveWidth-2, height-12, 0xffffff, 0, 2)
-   WindowLine(win, effectiveWidth-13, height-2, effectiveWidth-2, height-13, 0x696969, 0, 1)
+   if flat_theme == 1 then
+      resize_color_1 = 0x303030
+      resize_color_2 = 0x1c1c1c
+   else
+      resize_color_1 = 0xffffff
+      resize_color_2 = 0x696969
+   end
+   WindowLine(win, effectiveWidth-3, height-2, effectiveWidth-2, height-3, resize_color_1, 0, 2)
+   WindowLine(win, effectiveWidth-4, height-2, effectiveWidth-2, height-4, resize_color_2, 0, 1)
+   WindowLine(win, effectiveWidth-6, height-2, effectiveWidth-2, height-6, resize_color_1, 0, 2)
+   WindowLine(win, effectiveWidth-7, height-2, effectiveWidth-2, height-7, resize_color_2, 0, 1)
+   WindowLine(win, effectiveWidth-9, height-2, effectiveWidth-2, height-9, resize_color_1, 0, 2)
+   WindowLine(win, effectiveWidth-10, height-2, effectiveWidth-2, height-10, resize_color_2, 0, 1)
+   WindowLine(win, effectiveWidth-12, height-2, effectiveWidth-2, height-12, resize_color_1, 0, 2)
+   WindowLine(win, effectiveWidth-13, height-2, effectiveWidth-2, height-13, resize_color_2, 0, 1)
 
    BroadcastPlugin (999, "repaint")
 end -- DisplayStatsPage
@@ -338,6 +357,7 @@ end -- DisplayStatsPage
 -- right click menu
 function right_click_menu ()
    menustring ="!Change Font|"
+   menustring = menustring..((flat_theme==1 and "+") or "").."Flat Theme|"
    if showLabels == 1 then
       menustring = menustring.."Hide Labels|"
    else
@@ -375,9 +395,20 @@ function right_click_menu ()
             font_size = wanted_font.size
          end
       elseif numResult == 2 then
+         if flat_theme == 0 then
+            ColourNote ("yellow", "", "Flat Theme for status monitor is ENABLED.")
+            background_colour = 0x1c1c1c
+            border_color = 0x303030
+         else  
+            ColourNote ("yellow", "", "Flat Theme for status monitor is DISABLED.")
+            background_colour = 0x000000 
+            border_color = 0xcccccc 
+         end
+         flat_theme = (((0 == flat_theme) and 1) or 0)
+      elseif numResult == 3 then
          -- show/hide labels
          showLabels = (((showLabels == 0) and 1) or 0)
-      elseif numResult == 3 then
+      elseif numResult == 4 then
          -- stack/unstack bars
          if stacked == 1 then
             stacked = 0
@@ -386,22 +417,22 @@ function right_click_menu ()
             stacked = 1
             height = ((line_height+1)*numBars)+(TOP_MARGIN*2)
          end
-      elseif numResult >= 4 and numResult <= 9 then
+      elseif numResult >= 5 and numResult <= 10 then
          -- activate/de-activate
-         showBar[barIndex[numResult-3]][2] = not showBar[barIndex[numResult-3]][2]
-      elseif numResult >= 10 and numResult <= 21 then
+         showBar[barIndex[numResult-4]][2] = not showBar[barIndex[numResult-4]][2]
+      elseif numResult >= 11 and numResult <= 22 then
          -- change colors
-         local colourIndex = 4
+         local colourIndex = 5
          if (numResult % 2 == 1) then
-            colourIndex = 5
+            colourIndex = 4
          end
-         local newcolour = PickColour (showBar[barIndex[math.ceil((numResult-9)/2)]][colourIndex])
+         local newcolour = PickColour (showBar[barIndex[math.ceil((numResult-10)/2)]][colourIndex])
          if newcolour ~= -1 then
-            showBar[barIndex[math.ceil((numResult-9)/2)]][colourIndex] = newcolour
+            showBar[barIndex[math.ceil((numResult-10)/2)]][colourIndex] = newcolour
          end
-      elseif numResult == 22 then
-         thresh1active = (((thresh1active == 0) and 1) or 0)
       elseif numResult == 23 then
+         thresh1active = (((thresh1active == 0) and 1) or 0)
+      elseif numResult == 24 then
          local perc = utils.inputbox( "I want the HP bars to change color when they drop below this percent...\n(enter a whole number between 1 and 100)", "Group Monitor HP Threshold #1", thresh1percent, nil, nil, {validate=validate_percent})
          if perc then
             if string.sub(perc, -1) == "%" then
@@ -409,14 +440,14 @@ function right_click_menu ()
             end
             thresh1percent = tonumber(perc)
          end
-      elseif numResult == 24 then
+      elseif numResult == 25 then
          local newColor = PickColour (thresh1color)
          if newcolor ~= -1 then
             thresh1color = newColor
          end
-      elseif numResult == 25 then
-         thresh2active = (((thresh2active == 0) and 1) or 0)
       elseif numResult == 26 then
+         thresh2active = (((thresh2active == 0) and 1) or 0)
+      elseif numResult == 27 then
          local perc = utils.inputbox( "I want the HP bars to change color when they drop below this percent...\n(enter a whole number between 1 and 100)", "Group Monitor HP Threshold #2", thresh2percent, nil, nil, {validate=validate_percent})
          if perc then
             if string.sub(perc, -1) == "%" then
@@ -424,34 +455,34 @@ function right_click_menu ()
             end
             thresh2percent = tonumber(perc)
          end
-      elseif numResult == 27 then
+      elseif numResult == 28 then
          local newColor = PickColour (thresh2color)
          if newcolor ~= -1 then
             thresh2color = newColor
          end
-      elseif numResult == 28 then
+      elseif numResult == 29 then
          -- reverse tnl
          reverseTNL = (((reverseTNL == 0) and 1) or 0)
-      elseif numResult == 29 then
+      elseif numResult == 30 then
          -- text mode
          graphicalMode = (((graphicalMode == 0) and 1) or 0)
-      elseif numResult == 30 then
-         flat_gauges = (((flat_gauges == 0) and 1) or 0)
       elseif numResult == 31 then
-         overlay_numbers = 0
+         flat_gauges = (((flat_gauges == 0) and 1) or 0)
       elseif numResult == 32 then
-         overlay_numbers = 1
+         overlay_numbers = 0
       elseif numResult == 33 then
-         overlay_numbers = 2
+         overlay_numbers = 1
       elseif numResult == 34 then
-         overlay_numbers = 3
+         overlay_numbers = 2
       elseif numResult == 35 then
+         overlay_numbers = 3
+      elseif numResult == 36 then
          -- bring to front
          CallPlugin("462b665ecb569efbf261422f","boostMe", win)
-      elseif numResult == 36 then
+      elseif numResult == 37 then
          -- send to back
          CallPlugin("462b665ecb569efbf261422f","dropMe", win)
-      elseif numResult == 37 then
+      elseif numResult == 38 then
          -- reduce size
          font_name = default_font_name
          font_size = default_font_size
@@ -581,6 +612,7 @@ function OnPluginSaveState ()
    SetVariable ("height", height)
    SetVariable ("font_name", font_name)
    SetVariable ("font_size", font_size)
+   SetVariable ("flat_theme", flat_theme)
    SetVariable ("showBar", serialize.save ("showBar"))
    SetVariable ("graphicalMode", graphicalMode)
    SetVariable ("flat_gauges", flat_gauges)
@@ -622,7 +654,7 @@ function OnPluginWorldOutputResized()
 end
 
 function OnPluginInstall()
-   background_colour = tonumber (GetVariable ("background_colour")) or background_colour
+   --background_colour = tonumber (GetVariable ("background_colour")) or background_colour
    -- make window so I can grab the font info
    WindowCreate (win, 600, 600, 1, 1, 0, 0, background_colour)
 
@@ -649,6 +681,7 @@ function OnPluginInstall()
 
    font_name = GetVariable("font_name") or default_font_name
    font_size = tonumber(GetVariable("font_size")) or default_font_size
+   flat_theme = tonumber(GetVariable("flat_theme")) or 0
 
    --- Load the fonts into the temp window.
    WindowFont (win, font_id, font_name, font_size, false, false, false, false) -- normal font

--- a/MUSHclient/worlds/plugins/aard_health_bars_gmcp.xml
+++ b/MUSHclient/worlds/plugins/aard_health_bars_gmcp.xml
@@ -415,12 +415,12 @@ function right_click_menu ()
          end
       elseif numResult >= 5 and numResult <= 10 then
          -- activate/de-activate
-         showBar[barIndex[numResult-3]][2] = not showBar[barIndex[numResult-3]][2]
+         showBar[barIndex[numResult-4]][2] = not showBar[barIndex[numResult-4]][2]
       elseif numResult >= 11 and numResult <= 22 then
          -- change colors
-         local colourIndex = 4
+         local colourIndex = 5
          if (numResult % 2 == 1) then
-            colourIndex = 5
+            colourIndex = 4
          end
          local newcolour = PickColour (showBar[barIndex[math.ceil((numResult-9)/2)]][colourIndex])
          if newcolour ~= -1 then

--- a/MUSHclient/worlds/plugins/aard_health_bars_gmcp.xml
+++ b/MUSHclient/worlds/plugins/aard_health_bars_gmcp.xml
@@ -44,8 +44,7 @@ require "gauge"
 require "gmcphelper"
 require "serialize"
 
-background_colour     = 0x000000
-border_color          = 0xcccccc
+
 default_width         = 1137
 default_x             = 0
 default_y             = 552
@@ -68,6 +67,10 @@ thresh1percent = tonumber (GetVariable("thresh1percent")) or 40
 thresh2percent = tonumber (GetVariable("thresh2percent")) or 20
 thresh1color = tonumber (GetVariable("thresh1color")) or 0x00ffff
 thresh2color = tonumber (GetVariable("thresh2color")) or 0x0000ff
+
+--flat_theme = tonumber (GetVariable("flat_theme")) or 0
+background_colour     = 0x000000
+border_color          = 0xcccccc
 
 -- Variables not saved.
 startx     = ""
@@ -97,6 +100,7 @@ function reset_aard()
    width = default_width
    font_name = default_font_name
    font_size = default_font_size
+   flat_theme = 0
    windowinfo.window_left = default_x
    windowinfo.window_top = default_y
    WindowPosition(win, default_x, default_y, 0, 18)
@@ -320,17 +324,28 @@ function DisplayStatsPage()
 
    -- draw edge frame.
    WindowRectOp (win, 1, 0, 0, 0, 0, border_color, 15)
-   WindowRectOp (win, 1, 1, 1, -1, -1, 0x777777, 15)
+   if flat_theme == 1 then
+      --WindowRectOp (win, 1, 1, 1, -1, -1, 0x444444, 15)
+   else
+      WindowRectOp (win, 1, 1, 1, -1, -1, 0x777777, 15)
+   end
 
    -- draw the resize widget bottom right corner.
-   WindowLine(win, effectiveWidth-3, height-2, effectiveWidth-2, height-3, 0xffffff, 0, 2)
-   WindowLine(win, effectiveWidth-4, height-2, effectiveWidth-2, height-4, 0x696969, 0, 1)
-   WindowLine(win, effectiveWidth-6, height-2, effectiveWidth-2, height-6, 0xffffff, 0, 2)
-   WindowLine(win, effectiveWidth-7, height-2, effectiveWidth-2, height-7, 0x696969, 0, 1)
-   WindowLine(win, effectiveWidth-9, height-2, effectiveWidth-2, height-9, 0xffffff, 0, 2)
-   WindowLine(win, effectiveWidth-10, height-2, effectiveWidth-2, height-10, 0x696969, 0, 1)
-   WindowLine(win, effectiveWidth-12, height-2, effectiveWidth-2, height-12, 0xffffff, 0, 2)
-   WindowLine(win, effectiveWidth-13, height-2, effectiveWidth-2, height-13, 0x696969, 0, 1)
+   if flat_theme == 1 then
+      resize_color_1 = 0x303030
+      resize_color_2 = 0x1c1c1c
+   else
+      resize_color_1 = 0xffffff
+      resize_color_2 = 0x696969
+   end
+   WindowLine(win, effectiveWidth-3, height-2, effectiveWidth-2, height-3, resize_color_1, 0, 2)
+   WindowLine(win, effectiveWidth-4, height-2, effectiveWidth-2, height-4, resize_color_2, 0, 1)
+   WindowLine(win, effectiveWidth-6, height-2, effectiveWidth-2, height-6, resize_color_1, 0, 2)
+   WindowLine(win, effectiveWidth-7, height-2, effectiveWidth-2, height-7, resize_color_2, 0, 1)
+   WindowLine(win, effectiveWidth-9, height-2, effectiveWidth-2, height-9, resize_color_1, 0, 2)
+   WindowLine(win, effectiveWidth-10, height-2, effectiveWidth-2, height-10, resize_color_2, 0, 1)
+   WindowLine(win, effectiveWidth-12, height-2, effectiveWidth-2, height-12, resize_color_1, 0, 2)
+   WindowLine(win, effectiveWidth-13, height-2, effectiveWidth-2, height-13, resize_color_2, 0, 1)
 
    BroadcastPlugin (999, "repaint")
 end -- DisplayStatsPage
@@ -338,6 +353,7 @@ end -- DisplayStatsPage
 -- right click menu
 function right_click_menu ()
    menustring ="!Change Font|"
+   menustring = menustring..((flat_theme==1 and "+") or "").."Flat Theme|"
    if showLabels == 1 then
       menustring = menustring.."Hide Labels|"
    else
@@ -375,9 +391,20 @@ function right_click_menu ()
             font_size = wanted_font.size
          end
       elseif numResult == 2 then
+         if flat_theme == 0 then
+            ColourNote ("yellow", "", "Flat Theme for status monitor is ENABLED.")
+            background_colour = 0x1c1c1c
+            border_color = 0x303030
+         else  
+            ColourNote ("yellow", "", "Flat Theme for status monitor is DISABLED.")
+            background_colour = 0x000000 
+            border_color = 0xcccccc 
+         end
+         flat_theme = (((0 == flat_theme) and 1) or 0)
+      elseif numResult == 3 then
          -- show/hide labels
          showLabels = (((showLabels == 0) and 1) or 0)
-      elseif numResult == 3 then
+      elseif numResult == 4 then
          -- stack/unstack bars
          if stacked == 1 then
             stacked = 0
@@ -386,10 +413,10 @@ function right_click_menu ()
             stacked = 1
             height = ((line_height+1)*numBars)+(TOP_MARGIN*2)
          end
-      elseif numResult >= 4 and numResult <= 9 then
+      elseif numResult >= 5 and numResult <= 10 then
          -- activate/de-activate
          showBar[barIndex[numResult-3]][2] = not showBar[barIndex[numResult-3]][2]
-      elseif numResult >= 10 and numResult <= 21 then
+      elseif numResult >= 11 and numResult <= 22 then
          -- change colors
          local colourIndex = 4
          if (numResult % 2 == 1) then
@@ -399,9 +426,9 @@ function right_click_menu ()
          if newcolour ~= -1 then
             showBar[barIndex[math.ceil((numResult-9)/2)]][colourIndex] = newcolour
          end
-      elseif numResult == 22 then
-         thresh1active = (((thresh1active == 0) and 1) or 0)
       elseif numResult == 23 then
+         thresh1active = (((thresh1active == 0) and 1) or 0)
+      elseif numResult == 24 then
          local perc = utils.inputbox( "I want the HP bars to change color when they drop below this percent...\n(enter a whole number between 1 and 100)", "Group Monitor HP Threshold #1", thresh1percent, nil, nil, {validate=validate_percent})
          if perc then
             if string.sub(perc, -1) == "%" then
@@ -409,14 +436,14 @@ function right_click_menu ()
             end
             thresh1percent = tonumber(perc)
          end
-      elseif numResult == 24 then
+      elseif numResult == 25 then
          local newColor = PickColour (thresh1color)
          if newcolor ~= -1 then
             thresh1color = newColor
          end
-      elseif numResult == 25 then
-         thresh2active = (((thresh2active == 0) and 1) or 0)
       elseif numResult == 26 then
+         thresh2active = (((thresh2active == 0) and 1) or 0)
+      elseif numResult == 27 then
          local perc = utils.inputbox( "I want the HP bars to change color when they drop below this percent...\n(enter a whole number between 1 and 100)", "Group Monitor HP Threshold #2", thresh2percent, nil, nil, {validate=validate_percent})
          if perc then
             if string.sub(perc, -1) == "%" then
@@ -424,34 +451,34 @@ function right_click_menu ()
             end
             thresh2percent = tonumber(perc)
          end
-      elseif numResult == 27 then
+      elseif numResult == 28 then
          local newColor = PickColour (thresh2color)
          if newcolor ~= -1 then
             thresh2color = newColor
          end
-      elseif numResult == 28 then
+      elseif numResult == 29 then
          -- reverse tnl
          reverseTNL = (((reverseTNL == 0) and 1) or 0)
-      elseif numResult == 29 then
+      elseif numResult == 30 then
          -- text mode
          graphicalMode = (((graphicalMode == 0) and 1) or 0)
-      elseif numResult == 30 then
-         flat_gauges = (((flat_gauges == 0) and 1) or 0)
       elseif numResult == 31 then
-         overlay_numbers = 0
+         flat_gauges = (((flat_gauges == 0) and 1) or 0)
       elseif numResult == 32 then
-         overlay_numbers = 1
+         overlay_numbers = 0
       elseif numResult == 33 then
-         overlay_numbers = 2
+         overlay_numbers = 1
       elseif numResult == 34 then
-         overlay_numbers = 3
+         overlay_numbers = 2
       elseif numResult == 35 then
+         overlay_numbers = 3
+      elseif numResult == 36 then
          -- bring to front
          CallPlugin("462b665ecb569efbf261422f","boostMe", win)
-      elseif numResult == 36 then
+      elseif numResult == 37 then
          -- send to back
          CallPlugin("462b665ecb569efbf261422f","dropMe", win)
-      elseif numResult == 37 then
+      elseif numResult == 38 then
          -- reduce size
          font_name = default_font_name
          font_size = default_font_size
@@ -581,6 +608,7 @@ function OnPluginSaveState ()
    SetVariable ("height", height)
    SetVariable ("font_name", font_name)
    SetVariable ("font_size", font_size)
+   SetVariable ("flat_theme", flat_theme)
    SetVariable ("showBar", serialize.save ("showBar"))
    SetVariable ("graphicalMode", graphicalMode)
    SetVariable ("flat_gauges", flat_gauges)
@@ -622,7 +650,7 @@ function OnPluginWorldOutputResized()
 end
 
 function OnPluginInstall()
-   background_colour = tonumber (GetVariable ("background_colour")) or background_colour
+   --background_colour = tonumber (GetVariable ("background_colour")) or background_colour
    -- make window so I can grab the font info
    WindowCreate (win, 600, 600, 1, 1, 0, 0, background_colour)
 
@@ -649,6 +677,7 @@ function OnPluginInstall()
 
    font_name = GetVariable("font_name") or default_font_name
    font_size = tonumber(GetVariable("font_size")) or default_font_size
+   flat_theme = tonumber(GetVariable("flat_theme")) or 0
 
    --- Load the fonts into the temp window.
    WindowFont (win, font_id, font_name, font_size, false, false, false, false) -- normal font

--- a/MUSHclient/worlds/plugins/aard_health_bars_gmcp.xml
+++ b/MUSHclient/worlds/plugins/aard_health_bars_gmcp.xml
@@ -422,9 +422,9 @@ function right_click_menu ()
          if (numResult % 2 == 1) then
             colourIndex = 4
          end
-         local newcolour = PickColour (showBar[barIndex[math.ceil((numResult-9)/2)]][colourIndex])
+         local newcolour = PickColour (showBar[barIndex[math.ceil((numResult-10)/2)]][colourIndex])
          if newcolour ~= -1 then
-            showBar[barIndex[math.ceil((numResult-9)/2)]][colourIndex] = newcolour
+            showBar[barIndex[math.ceil((numResult-10)/2)]][colourIndex] = newcolour
          end
       elseif numResult == 23 then
          thresh1active = (((thresh1active == 0) and 1) or 0)

--- a/MUSHclient/worlds/plugins/aard_health_bars_gmcp.xml
+++ b/MUSHclient/worlds/plugins/aard_health_bars_gmcp.xml
@@ -44,7 +44,6 @@ require "gauge"
 require "gmcphelper"
 require "serialize"
 
-
 default_width         = 1137
 default_x             = 0
 default_y             = 552
@@ -68,9 +67,14 @@ thresh2percent = tonumber (GetVariable("thresh2percent")) or 20
 thresh1color = tonumber (GetVariable("thresh1color")) or 0x00ffff
 thresh2color = tonumber (GetVariable("thresh2color")) or 0x0000ff
 
---flat_theme = tonumber (GetVariable("flat_theme")) or 0
-background_colour     = 0x000000
-border_color          = 0xcccccc
+flat_theme = tonumber (GetVariable("flat_theme")) or 0
+if flat_theme == 1 then
+   background_colour = 0x1c1c1c
+   border_color = 0x303030
+else  
+   background_colour = 0x000000 
+   border_color = 0xcccccc 
+end
 
 -- Variables not saved.
 startx     = ""

--- a/MUSHclient/worlds/plugins/aard_layout.xml
+++ b/MUSHclient/worlds/plugins/aard_layout.xml
@@ -46,6 +46,14 @@
    sequence="100"
    ignore_case="y"
 ></alias>
+
+<alias
+   script="flat_theme_init"
+   match="flat_theme"
+   enabled="y"
+   sequence="100"
+   ignore_case="y"
+></alias>
 </aliases>
 
 <!--  Script  -->
@@ -192,13 +200,27 @@ function OnPluginSaveState ()
    SetVariable("trright",textrect_right)
    SetVariable("trtop",textrect_top)
    SetVariable("trbottom",textrect_bottom)
+   SetVariable("flat_theme", flat_theme)
 end -- OnPluginSaveState
+
+function flat_theme_init()
+   if flat_theme == 0 then
+      ColourNote ("yellow", "", "Flat Theme for main window is ENABLED.")
+   else  
+      ColourNote ("yellow", "", "Flat Theme for main window is DISABLED.")
+   end
+   flat_theme = (((0 == flat_theme) and 1) or 0)
+   OnPluginEnable()
+   WindowDelete(textResizer)
+   add_main_resizer()
+end
 
 function reset_aard()
    textrect_left = default_left
    textrect_right = default_right
    textrect_top = default_top
    textrect_bottom = default_bottom
+   flat_theme = 0
    OnPluginSaveState()
    check_main_background()
 end
@@ -235,6 +257,14 @@ end -- OnPluginEnable
 -- This is the place to initialize stuff you need in the main plugin.
 --=================================================================================
 function OnPluginInstall()
+   flat_theme = tonumber(GetVariable("flat_theme")) or 0
+
+   if flat_theme == 1 then
+      background_colour = 0x1c1c1c
+   else
+      background_colour = 0x000000
+   end
+
    --- Get a unique name for main window and resizer window.
    win = GetPluginID ()  -- get a unique name
    textDragger = "      "..win.."txtdragger"
@@ -248,8 +278,8 @@ function OnPluginInstall()
       ColourNote("yellow","red","Error loading background image.")
    end
 
-   WindowCreate (bgwin, 0, 0, 0, 0, 12, 3, GetNormalColour(1))
-   WindowCreate (bgoffscreen, 0, 0, 0, 0, 12, 3, GetNormalColour(1))
+   WindowCreate (bgwin, 0, 0, 0, 0, 12, 3, background_colour)
+   WindowCreate (bgoffscreen, 0, 0, 0, 0, 12, 3, background_colour)
 
    local logopath = dir .. "worlds\\plugins\\images\\aardbg13.png"
    if WindowLoadImage (bgoffscreen, "wolf_logo", logopath) == 0 then
@@ -295,16 +325,23 @@ function add_main_resizer()
          12  , 2, GetNormalColour(1)))
 
       -- draw the resize widget bottom right corner.
-      WindowLine(textResizer, rstagsize-1, rstagsize-0, rstagsize-0, rstagsize-1, 0xffffff, 0, 2)
-      WindowLine(textResizer, rstagsize-2, rstagsize-0, rstagsize-0, rstagsize-2, 0x696969, 0, 1)
-      WindowLine(textResizer, rstagsize-4, rstagsize-0, rstagsize-0, rstagsize-4, 0xffffff, 0, 2)
-      WindowLine(textResizer, rstagsize-5, rstagsize-0, rstagsize-0, rstagsize-5, 0x696969, 0, 1)
-      WindowLine(textResizer, rstagsize-7, rstagsize-0, rstagsize-0, rstagsize-7, 0xffffff, 0, 2)
-      WindowLine(textResizer, rstagsize-8, rstagsize-0, rstagsize-0, rstagsize-8, 0x696969, 0, 1)
-      WindowLine(textResizer, rstagsize-10, rstagsize-0, rstagsize-0, rstagsize-10, 0xffffff, 0, 2)
-      WindowLine(textResizer, rstagsize-11, rstagsize-0, rstagsize-0, rstagsize-11, 0x696969, 0, 1)
-      WindowLine(textResizer, rstagsize-12, rstagsize-0, rstagsize-0, rstagsize-12, 0xffffff, 0, 1)
-      WindowLine(textResizer, rstagsize-13, rstagsize-0, rstagsize-0, rstagsize-13, 0xffffff, 0, 1)
+      if flat_theme == 1 then
+         resize_color_1 = 0x303030
+         resize_color_2 = 0x1c1c1c
+      else
+         resize_color_1 = 0xffffff
+         resize_color_2 = 0x696969
+      end
+      WindowLine(textResizer, rstagsize-1, rstagsize-0, rstagsize-0, rstagsize-1, resize_color_1, 0, 2)
+      WindowLine(textResizer, rstagsize-2, rstagsize-0, rstagsize-0, rstagsize-2, resize_color_2, 0, 1)
+      WindowLine(textResizer, rstagsize-4, rstagsize-0, rstagsize-0, rstagsize-4, resize_color_1, 0, 2)
+      WindowLine(textResizer, rstagsize-5, rstagsize-0, rstagsize-0, rstagsize-5, resize_color_2, 0, 1)
+      WindowLine(textResizer, rstagsize-7, rstagsize-0, rstagsize-0, rstagsize-7, resize_color_1, 0, 2)
+      WindowLine(textResizer, rstagsize-8, rstagsize-0, rstagsize-0, rstagsize-8, resize_color_2, 0, 1)
+      WindowLine(textResizer, rstagsize-10, rstagsize-0, rstagsize-0, rstagsize-10, resize_color_1, 0, 2)
+      WindowLine(textResizer, rstagsize-11, rstagsize-0, rstagsize-0, rstagsize-11, resize_color_2, 0, 1)
+      WindowLine(textResizer, rstagsize-12, rstagsize-0, rstagsize-0, rstagsize-12, resize_color_1, 0, 1)
+      WindowLine(textResizer, rstagsize-13, rstagsize-0, rstagsize-0, rstagsize-13, resize_color_1, 0, 1)
 
       -- Add a drag handler to this window, effectively allows textrectangle to be resized.
       WindowAddHotspot(textResizer, "resizemain", 0, 0, 0, 0, "MouseOver", "CancelMouseOver", "MouseDown", "CancelMouseDown", "MouseUp", "", 6, 0)
@@ -339,11 +376,21 @@ function draw_main_window()
    local t_right = math.min(textrect_right,GetInfo(281)-7)
    local t_bottom = math.min(textrect_bottom, GetInfo(280)-7)
 
+   if flat_theme == 1 then
+      offset = 3
+      border_colour = 0x303030
+      outside_colour = 0x444444
+   else
+      offset = 5
+      border_colour = ColourNameToRGB("darkgray")
+      outside_colour = 0x333333
+   end
+
    TextRectangle(textrect_left, textrect_top, t_right, t_bottom,
-      5,  -- BorderOffset,
-      ColourNameToRGB ("darkgray"),    -- BorderColour,
+      offset,  -- BorderOffset,
+      border_colour,    -- BorderColour,
       2,  -- BorderWidth,
-      0x333333,  -- OutsideFillColour,
+      outside_colour,  -- OutsideFillColour,
       miniwin.brush_solid) -- OutsideFillStyle
 
    -- Add a mini-window under main text area so background won't mess it up.
@@ -352,7 +399,7 @@ function draw_main_window()
 
    WindowCreate (bgwin, textrect_left - 5, textrect_top - 5,
       math.max(0, trwidth + 10), math.max(0, trheight + 10),
-      12  , 3, GetNormalColour(1))
+      12  , 3, background_colour)
    WindowShow(bgwin, true)
 
    if image_ratio ~= nil then
@@ -365,7 +412,9 @@ function draw_main_window()
          image_width = trwidth
       end
 
-      WindowDrawImage (bgwin, "wolf_logo", (trwidth-image_width)/2, (trheight-image_height)/2, (trwidth+image_width)/2, (trheight+image_height)/2, miniwin.image_stretch)
+      if flat_theme == 0 then
+         WindowDrawImage (bgwin, "wolf_logo", (trwidth-image_width)/2, (trheight-image_height)/2, (trwidth+image_width)/2, (trheight+image_height)/2, miniwin.image_stretch)
+      end
    end
 
    add_title_dragger()

--- a/MUSHclient/worlds/plugins/aard_statmon_gmcp.xml
+++ b/MUSHclient/worlds/plugins/aard_statmon_gmcp.xml
@@ -462,17 +462,28 @@ function Print()
 
    -- draw edge frame.
    WindowRectOp (win, 1, 0, 0, 0, 0, border_colour, 15)
-   WindowRectOp (win, 1, 1, 1, -1, -1, 0x777777, 15)
+   if flat_theme == 1 then
+      --WindowRectOp (win, 1, 1, 1, -1, -1, 0x444444, 15)
+   else
+      WindowRectOp (win, 1, 1, 1, -1, -1, 0x777777, 15)
+   end
 
    -- draw the resize widget bottom right corner.
-   WindowLine(win, width-3, height-2, width-2, height-3, 0xffffff, 0, 2)
-   WindowLine(win, width-4, height-2, width-2, height-4, 0x696969, 0, 1)
-   WindowLine(win, width-6, height-2, width-2, height-6, 0xffffff, 0, 2)
-   WindowLine(win, width-7, height-2, width-2, height-7, 0x696969, 0, 1)
-   WindowLine(win, width-9, height-2, width-2, height-9, 0xffffff, 0, 2)
-   WindowLine(win, width-10, height-2, width-2, height-10, 0x696969, 0, 1)
-   WindowLine(win, width-12, height-2, width-2, height-12, 0xffffff, 0, 2)
-   WindowLine(win, width-13, height-2, width-2, height-13, 0x696969, 0, 1)
+   if flat_theme == 1 then
+      resize_color_1 = 0x303030
+      resize_color_2 = 0x1c1c1c
+   else
+      resize_color_1 = 0xffffff
+      resize_color_2 = 0x696969
+   end
+   WindowLine(win, width-3, height-2, width-2, height-3, resize_color_1, 0, 2)
+   WindowLine(win, width-4, height-2, width-2, height-4, resize_color_2, 0, 1)
+   WindowLine(win, width-6, height-2, width-2, height-6, resize_color_1, 0, 2)
+   WindowLine(win, width-7, height-2, width-2, height-7, resize_color_2, 0, 1)
+   WindowLine(win, width-9, height-2, width-2, height-9, resize_color_1, 0, 2)
+   WindowLine(win, width-10, height-2, width-2, height-10, resize_color_2, 0, 1)
+   WindowLine(win, width-12, height-2, width-2, height-12, resize_color_1, 0, 2)
+   WindowLine(win, width-13, height-2, width-2, height-13, resize_color_2, 0, 1)
 
    BroadcastPlugin (999, "repaint")
 end
@@ -498,7 +509,7 @@ function right_click_menu ()
       colorstring = colorstring..">"..v.."|"..v.." Label ("..RGBColourToName(label_colors[v])..")|"..v.." Data ("..RGBColourToName(data_colors[v])..")|<|"
    end
 
-   menustring = "Flip Orientation|Change Font|>Colors|"..colorstring.."<|"..(commas_in_gold and "+" or "").."Commas in Gold|-|Bring To Front|Send To Back|-|Reset Defaults"
+   menustring = "Flip Orientation|Change Font|"..((flat_theme==1 and "+") or "").."Flat Theme|>Colors|"..colorstring.."<|"..(commas_in_gold and "+" or "").."Commas in Gold|-|Bring To Front|Send To Back|-|Reset Defaults"
 
    result = WindowMenu (win,
       WindowInfo (win, 14),  -- x position
@@ -546,6 +557,19 @@ function right_click_menu ()
             SetUpHotspotsAndDraw()
          end
       end
+   elseif result == "Flat Theme" then
+      if flat_theme == 0 then
+         ColourNote ("yellow", "", "Flat Theme for status monitor is ENABLED.")
+         background_colour = 0x1c1c1c
+         border_colour = 0x303030
+      else  
+         ColourNote ("yellow", "", "Flat Theme for status monitor is DISABLED.")
+         background_colour = 0x000000 
+         border_colour = 0xcccccc 
+      end
+      flat_theme = (((0 == flat_theme) and 1) or 0)
+      SetVariable("flat_theme", flat_theme)
+      OnPluginInstall()
    elseif string.find(result,"Label") then
       local item = string.sub(result,1,string.find(result,"Label")-2)
       if item == "All" then
@@ -608,6 +632,7 @@ function right_click_menu ()
       font_size        = default_font_size
       height           = default_height
       width            = default_width
+      flat_theme       = 0
       stacked = 0
       label_colors = copytable.deep(label_color_defaults)
       data_colors = copytable.deep(data_color_defaults)
@@ -730,6 +755,7 @@ function OnPluginSaveState ()
    SetVariable ("height", height)
    SetVariable ("font_name", font_name)
    SetVariable ("font_size", font_size)
+   SetVariable ("flat_theme", flat_theme)
    SetVariable ("stacked", stacked)
    SetVariable ("commas_in_gold", commas_in_gold and 1 or 0)
    SetVariable ("label_colors", serialize.save("label_colors"))
@@ -788,6 +814,7 @@ function OnPluginInstall()
    commas_in_gold = tonumber(GetVariable("commas_in_gold")) == 1
    font_name = GetVariable("font_name") or default_font_name
    font_size = tonumber(GetVariable("font_size")) or default_font_size
+   flat_theme = tonumber(GetVariable("flat_theme")) or 0
 
    --- Load the fonts into the temp window.
    WindowFont (win, font_id, font_name, font_size, false, false, false, false) -- normal font
@@ -800,7 +827,7 @@ function OnPluginInstall()
    max_height = (line_height*(((stacked == 1) and 12) or 23))+(TOP_MARGIN+1)
 
    --- Pull some state variables.
-   background_colour = tonumber (GetVariable ("background_colour")) or background_colour
+   --background_colour = tonumber (GetVariable ("background_colour")) or background_colour
    height = tonumber (GetVariable ("height")) or default_height
    orig_height = height
    width = tonumber (GetVariable ("width")) or default_width

--- a/MUSHclient/worlds/plugins/aard_statmon_gmcp.xml
+++ b/MUSHclient/worlds/plugins/aard_statmon_gmcp.xml
@@ -41,8 +41,14 @@ require "commas"
 require "gmcphelper"
 require "copytable"
 
-background_colour     = 0x000000
-border_colour         = 0xcccccc
+flat_theme = tonumber (GetVariable("flat_theme")) or 0
+if flat_theme == 1 then
+   background_colour = 0x1c1c1c
+   border_colour = 0x303030
+else  
+   background_colour = 0x000000 
+   border_colour = 0xcccccc 
+end
 default_width         = 209
 default_height        = 287
 default_x             = 658
@@ -462,17 +468,28 @@ function Print()
 
    -- draw edge frame.
    WindowRectOp (win, 1, 0, 0, 0, 0, border_colour, 15)
-   WindowRectOp (win, 1, 1, 1, -1, -1, 0x777777, 15)
+   if flat_theme == 1 then
+      --WindowRectOp (win, 1, 1, 1, -1, -1, 0x444444, 15)
+   else
+      WindowRectOp (win, 1, 1, 1, -1, -1, 0x777777, 15)
+   end
 
    -- draw the resize widget bottom right corner.
-   WindowLine(win, width-3, height-2, width-2, height-3, 0xffffff, 0, 2)
-   WindowLine(win, width-4, height-2, width-2, height-4, 0x696969, 0, 1)
-   WindowLine(win, width-6, height-2, width-2, height-6, 0xffffff, 0, 2)
-   WindowLine(win, width-7, height-2, width-2, height-7, 0x696969, 0, 1)
-   WindowLine(win, width-9, height-2, width-2, height-9, 0xffffff, 0, 2)
-   WindowLine(win, width-10, height-2, width-2, height-10, 0x696969, 0, 1)
-   WindowLine(win, width-12, height-2, width-2, height-12, 0xffffff, 0, 2)
-   WindowLine(win, width-13, height-2, width-2, height-13, 0x696969, 0, 1)
+   if flat_theme == 1 then
+      resize_color_1 = 0x303030
+      resize_color_2 = 0x1c1c1c
+   else
+      resize_color_1 = 0xffffff
+      resize_color_2 = 0x696969
+   end
+   WindowLine(win, width-3, height-2, width-2, height-3, resize_color_1, 0, 2)
+   WindowLine(win, width-4, height-2, width-2, height-4, resize_color_2, 0, 1)
+   WindowLine(win, width-6, height-2, width-2, height-6, resize_color_1, 0, 2)
+   WindowLine(win, width-7, height-2, width-2, height-7, resize_color_2, 0, 1)
+   WindowLine(win, width-9, height-2, width-2, height-9, resize_color_1, 0, 2)
+   WindowLine(win, width-10, height-2, width-2, height-10, resize_color_2, 0, 1)
+   WindowLine(win, width-12, height-2, width-2, height-12, resize_color_1, 0, 2)
+   WindowLine(win, width-13, height-2, width-2, height-13, resize_color_2, 0, 1)
 
    BroadcastPlugin (999, "repaint")
 end
@@ -498,7 +515,7 @@ function right_click_menu ()
       colorstring = colorstring..">"..v.."|"..v.." Label ("..RGBColourToName(label_colors[v])..")|"..v.." Data ("..RGBColourToName(data_colors[v])..")|<|"
    end
 
-   menustring = "Flip Orientation|Change Font|>Colors|"..colorstring.."<|"..(commas_in_gold and "+" or "").."Commas in Gold|-|Bring To Front|Send To Back|-|Reset Defaults"
+   menustring = "Flip Orientation|Change Font|"..((flat_theme==1 and "+") or "").."Flat Theme|>Colors|"..colorstring.."<|"..(commas_in_gold and "+" or "").."Commas in Gold|-|Bring To Front|Send To Back|-|Reset Defaults"
 
    result = WindowMenu (win,
       WindowInfo (win, 14),  -- x position
@@ -546,6 +563,19 @@ function right_click_menu ()
             SetUpHotspotsAndDraw()
          end
       end
+   elseif result == "Flat Theme" then
+      if flat_theme == 0 then
+         ColourNote ("yellow", "", "Flat Theme for status monitor is ENABLED.")
+         background_colour = 0x1c1c1c
+         border_colour = 0x303030
+      else  
+         ColourNote ("yellow", "", "Flat Theme for status monitor is DISABLED.")
+         background_colour = 0x000000 
+         border_colour = 0xcccccc 
+      end
+      flat_theme = (((0 == flat_theme) and 1) or 0)
+      SetVariable("flat_theme", flat_theme)
+      OnPluginInstall()
    elseif string.find(result,"Label") then
       local item = string.sub(result,1,string.find(result,"Label")-2)
       if item == "All" then
@@ -608,6 +638,7 @@ function right_click_menu ()
       font_size        = default_font_size
       height           = default_height
       width            = default_width
+      flat_theme       = 0
       stacked = 0
       label_colors = copytable.deep(label_color_defaults)
       data_colors = copytable.deep(data_color_defaults)
@@ -730,6 +761,7 @@ function OnPluginSaveState ()
    SetVariable ("height", height)
    SetVariable ("font_name", font_name)
    SetVariable ("font_size", font_size)
+   SetVariable ("flat_theme", flat_theme)
    SetVariable ("stacked", stacked)
    SetVariable ("commas_in_gold", commas_in_gold and 1 or 0)
    SetVariable ("label_colors", serialize.save("label_colors"))
@@ -788,6 +820,7 @@ function OnPluginInstall()
    commas_in_gold = tonumber(GetVariable("commas_in_gold")) == 1
    font_name = GetVariable("font_name") or default_font_name
    font_size = tonumber(GetVariable("font_size")) or default_font_size
+   flat_theme = tonumber(GetVariable("flat_theme")) or 0
 
    --- Load the fonts into the temp window.
    WindowFont (win, font_id, font_name, font_size, false, false, false, false) -- normal font
@@ -800,7 +833,7 @@ function OnPluginInstall()
    max_height = (line_height*(((stacked == 1) and 12) or 23))+(TOP_MARGIN+1)
 
    --- Pull some state variables.
-   background_colour = tonumber (GetVariable ("background_colour")) or background_colour
+   --background_colour = tonumber (GetVariable ("background_colour")) or background_colour
    height = tonumber (GetVariable ("height")) or default_height
    orig_height = height
    width = tonumber (GetVariable ("width")) or default_width

--- a/MUSHclient/worlds/plugins/aard_statmon_gmcp.xml
+++ b/MUSHclient/worlds/plugins/aard_statmon_gmcp.xml
@@ -41,8 +41,14 @@ require "commas"
 require "gmcphelper"
 require "copytable"
 
-background_colour     = 0x000000
-border_colour         = 0xcccccc
+flat_theme = tonumber (GetVariable("flat_theme")) or 0
+if flat_theme == 1 then
+   background_colour = 0x1c1c1c
+   border_colour = 0x303030
+else  
+   background_colour = 0x000000 
+   border_colour = 0xcccccc 
+end
 default_width         = 209
 default_height        = 287
 default_x             = 658


### PR DESCRIPTION
Add support for a window visual style inspired by modern text editors (Visual Studio Code, Atom, Sublime, etc.).

My old-man eyes can no longer take the super high contrast of solid black backgrounds, bright borders, and neon text. After playing around with things, I found what I believe to be a very nice "muted" style that takes its inspiration from Visual Studio Code (and similar) editors. I've attempted to integrate the change in such a way that it could be rolled into the main suite. Each plugin offers a "Flat Theme" menu entry (the main window can be enabled with the alias 'flat_theme'). 

No harm if you don't want to roll this in. I just wanted to ensure I didn't have to keep re-making the same edits after the client updates. 

An example screenshot with the flat theme enabled for all the windows (ascii map not displayed, but shares the same look). This is a custom colorset as well - not completely finalized, but I intend to document those settings as part of the whole "package" 

![image](https://cloud.githubusercontent.com/assets/693706/24084682/d002c650-0cbc-11e7-8980-f0dd88a8b1fb.png)
