### PR TITLE
Add timestamp consistency to StoreFromOutside

### DIFF
--- a/MUSHclient/worlds/plugins/aard_channels_fiendish.xml
+++ b/MUSHclient/worlds/plugins/aard_channels_fiendish.xml
@@ -733,8 +733,10 @@ function storeFromOutside(msg, tab)
       tab = findTab(tab)
    end
 
+   timestamp = os.date(date_format)
+
    if tab then
-      local should_redraw = storeTab(ColoursToStyles(msg), tab)
+      local should_redraw = storeTab(ColoursToStyles(timestamp..msg), tab)
       if should_redraw == true then
          drawTabs()
       end


### PR DESCRIPTION
Tweaked StoreFromOutside to adhere to timestamp setting. Currently external lines get no timestamp.