### PR TITLE
Update aard_soundpack.xml

### DIFF
--- a/MUSHclient/worlds/plugins/aard_soundpack.xml
+++ b/MUSHclient/worlds/plugins/aard_soundpack.xml
@@ -1292,6 +1292,10 @@ function TriggerEvent(event)
       logmsg("Event " .. event .. " has fired, but event volume is set to 0. Ignoring.")
       return
    end
+   -- Added this so if another plugin calls TriggerEvent() and soundpack is muted, it will not play the sound
+   if sp_mute_toggle == "1" then
+      return
+   end
    logmsg("Event " .. event .. " has fired!")
    volume = calc_volume(volume)
 


### PR DESCRIPTION
Fix to prevent audio playing when other plugins call TriggerEvent() to play a sound when the soundpack is muted/off.