### PR TITLE
Add map_find_query function to aard_GMCP_mapper.xml.

### DIFF
--- a/MUSHclient/lua/aardmapper.lua
+++ b/MUSHclient/lua/aardmapper.lua
@@ -1164,7 +1164,7 @@ function hyperlinkGoto(uid)
 end
 
 require "serialize"
-function full_find (name, dests, show_uid, expected_count, walk, fcb, no_portals)
+function full_find (dests, show_uid, expected_count, walk, fcb, no_portals)
    local paths = {}
    local notfound = {}
    for i,v in ipairs(dests) do
@@ -1271,7 +1271,7 @@ function full_find (name, dests, show_uid, expected_count, walk, fcb, no_portals
    Note("+-------------------------------- END OF SEARCH -------------------------------+")
 end
 
-function quick_find(name, dests, show_uid, expected_count, walk, fcb)
+function quick_find(dests, show_uid, expected_count, walk, fcb)
    CallPlugin("abc1a0944ae4af7586ce88dc", "BufferedRepaint")
    Note("+------------------------------ START OF SEARCH -------------------------------+")
 
@@ -1352,7 +1352,9 @@ function goto(uid)
 end
 
 -- generic room finder
+-- name is for informational purposes only; it's displayed to the user in the search results
 -- dests is a list of room/reason pairs where reason is either true (meaning generic) or a string to find
+-- if max_paths <= 0 it's disregarded, otherwise number of dests must be <= max_paths
 -- show_uid is true if you want the room uid to be displayed
 -- expected_count is the number we expect to find (eg. the number found on a database)
 -- if 'walk' is true, we walk to the first match rather than displaying hyperlinks
@@ -1384,9 +1386,9 @@ function find (name, dests, max_paths, show_uid, expected_count, walk, fcb, quic
    end
 
    if quick_list == true then
-      quick_find(name, dests, show_uid, expected_count, walk, fcb)
+      quick_find(dests, show_uid, expected_count, walk, fcb)
    else
-      full_find(name, dests, show_uid, expected_count, walk, fcb, no_portals)
+      full_find(dests, show_uid, expected_count, walk, fcb, no_portals)
    end
 end -- map_find_things
 

--- a/MUSHclient/worlds/plugins/aard_GMCP_mapper.xml
+++ b/MUSHclient/worlds/plugins/aard_GMCP_mapper.xml
@@ -3785,6 +3785,45 @@ function compact_mode_toggle(name, line, wildcards)
    if not compact_mode then Note("") end
 end
 
+-- Queries db for a list of rooms and passes them to mapper.find(). Can be used with CallPlugin().
+-- query: SQL query to run. Should return a list of rooms with uids. Example:
+--        "SELECT uid FROM rooms WHERE name = 'The Grand City of Aylor'"
+-- The remaining args are the same as the args to find() in aardmapper.lua. Their default values
+-- are given below. "fcb" is missing here since function args can't be used with CallPlugin().
+-- name: Defaults to nil.
+-- max_paths: Defaults to 0 (unlimited).
+-- show_uid: Defaults to true.
+-- walk: Defaults to false.
+-- quick_list: Defaults to false.
+-- no_portals: Defaults to false.
+function map_find_query(query, name, max_paths, show_uid, walk, quick_list, no_portals)
+   -- Default arguments.
+   max_paths = max_paths or 0
+   if show_uid == nil then show_uid = true end
+   walk = walk or false
+   quick_list = quick_list or false
+   no_portals = no_portals or false
+
+   local rooms = {}
+   local count = 0
+
+   for row in dbnrowsWRAPPER(query) do
+      table.insert(rooms, {uid=row.uid, reason=true})
+      count = count + 1
+   end
+
+   mapper.find(
+      name,
+      rooms,
+      max_paths,
+      show_uid,
+      count,      -- expected_count
+      walk,
+      nil,        -- fcb
+      quick_list 
+   )
+end -- map_find_query
+
 function map_area (name, line, wildcards)
 
    uid = mapper.current_room
@@ -3811,59 +3850,38 @@ function map_area (name, line, wildcards)
 
    local area = rooms[uid].area
 
-   local rooms = {}
-   local count = 0
-
    local key = Trim(wildcards[1])
    local name = "%"..key.."%"
    if string.sub(key,1,1) == "\"" and string.sub(key,-1) == "\"" then
       name = Trim(string.sub(key,2,-2))
    end
-   for row in dbnrowsWRAPPER(string.format ("SELECT uid, name, area FROM rooms WHERE trim(name) LIKE %s and area = %s", fixsql(name), fixsql(area))) do
-      table.insert(rooms,{uid=row.uid, reason=true})
-      count = count + 1
-   end   -- finding room
 
-   -- see if nearby
-
-   mapper.find (name,
-      rooms,
-      50,
-      show_vnums,  -- show vnum?
-      count,      -- how many to expect
-      false,       -- don't auto-walk
-      nil,
-      quick_mode
+   map_find_query(
+      string.format("SELECT uid, name, area FROM rooms WHERE trim(name) LIKE %s and area = %s",fixsql(name), fixsql(area)),
+      name,
+      50,          -- max_paths
+      show_vnums,  -- show_uid
+      false,       -- walk
+      quick_mode   -- quick_list
    )
-
 end -- map_area
 
 
 function map_find (name, line, wildcards)
-
-   local rooms = {}
-   local count = 0
-
    -- find matching rooms using FTS3
    local name = "%"..wildcards[1].."%"
 
    if string.sub(wildcards[1],1,1) == "\"" and string.sub(wildcards[1],-1) == "\"" then
       name = string.sub(wildcards[1],2,-2)
    end
-   for row in dbnrowsWRAPPER(string.format ("SELECT uid, name FROM rooms_lookup WHERE rooms_lookup.name LIKE %s", fixsql (name))) do
-      table.insert(rooms, {uid=row.uid, reason=true})
-      count = count + 1
-   end   -- finding room
 
-   -- see if nearby
-   mapper.find (name,
-      rooms,  -- function
-      50,
-      show_vnums,  -- show vnum?
-      count,      -- how many to expect
-      false,       -- don't auto-walk
-      nil,
-      quick_mode
+   map_find_query(
+      string.format("SELECT uid, name FROM rooms_lookup WHERE rooms_lookup.name LIKE %s", fixsql (name)),
+      name,
+      50,          -- max_paths
+      show_vnums,  -- show_uid
+      false,       -- walk
+      quick_mode   -- quick_list
    )
 end -- map_find
 


### PR DESCRIPTION
This allows users and other plugins to call mapper.find() with arbitrary SQL queries.

I also refactored a couple of functions to use map_find_query(), and removed a couple of unused args in aardmapper.lua.