### PR TITLE
Update aard_GMCP_mapper.xml

### DIFF
--- a/MUSHclient/worlds/plugins/aard_GMCP_mapper.xml
+++ b/MUSHclient/worlds/plugins/aard_GMCP_mapper.xml
@@ -4601,6 +4601,7 @@ function findpath(src, dst, noportals, norecalls)
 --      end
       table.insert(path, {dir=ftd.dir, uid=ftd.touid})
    end -- while
+   BroadcastPlugin(502, "found_paths = "..string.gsub(serialize.save_simple(path),"%s+"," "))
    return path, found_depth
 end -- function findpath
 


### PR DESCRIPTION
Lets the user use CallFunction on findpath() and capture the results (path and distance between 2 rooms) without printing output to the screen.