### PR TITLE
Stop storing critical hits in VI review buffers

### DIFF
--- a/MUSHclient/worlds/plugins/aard_vi_review_buffers.xml
+++ b/MUSHclient/worlds/plugins/aard_vi_review_buffers.xml
@@ -311,7 +311,7 @@ category. You could also create your own category.
   <trigger
    enabled="y"
    group="Alert"
-   match="^\*(?!\*)(.*)$"
+   match="^\*(?!\*)(.*)[^*\]]$"
    name="GlobalEmoteTrigger"
    regexp="y"
    send_to="12"


### PR DESCRIPTION
@fiendish Small fix for a relatively annoying problem that's been in the plugin since forever. I've had this fix in my private version for a few years; works well for me...

Address an issue with the GlobalEmoteTrigger trigger in the Aardwolf_Review_Buffers plugin where the regex was capturing tons of unrelated messages (mostly critical hits) and storing them all in the `All` and `Say` buffers, which made it very difficult to keep up with the Say channel while in combat.

The trigger now looks only for messages that start with a single "*" but that do not end with a "*" or "]". "]" is the final character in most damage messages in all damage settings (e.g., "*[7] Your light does UNBELIEVABLE things to the dazzling ocean sky! [11001]"). "*" is added to these when the attacker has holy reprisal, so we exclude those as well. The change does force the trigger to watch for lines of minimum length 2 instead of the previous 1; this shouldn't really matter, as lines consisting of only "*" should likewise not be captured.

The trigger will still find some false-positives on occasion (e.g., the School of Horror repop message: "*RING RING* Classes have begun! Good Luck!"). These instances are much more difficult to differentiate without something like {rsocial} tags being sent by the MUD, but they are much less common and really shouldn't cause anyone too much problem in practice.