### PR TITLE
Allow Aardwolf_Vital_Shortcuts to Accept Abbreviated Names

### DIFF
--- a/MUSHclient/worlds/plugins/aard_vital_shortcuts.xml
+++ b/MUSHclient/worlds/plugins/aard_vital_shortcuts.xml
@@ -95,6 +95,17 @@ function help()
 end
 
 
+-- Determine whether the string `str` starts with `prefix`. Set
+-- the third argument to `true` to do a case-sensitive match.
+function starts_with(str, prefix, caseSensitive)
+   if not caseSensitive then
+      str = str:lower()
+      prefix = prefix:lower()
+   end
+   return str:sub(1, #prefix) == prefix
+end
+
+
 function percent_format(current, max)
    local pct = math.floor(current * 100 / max)
    local color = "lightgreen"
@@ -135,7 +146,7 @@ function their_stats(who, stat)
    end
    member = nil
    for _,m in ipairs(group_members) do
-      if m["name"]:lower() == who:lower() then
+      if starts_with(m.name, who) then
          member = m
          break
       end

--- a/MUSHclient/worlds/plugins/aard_vital_shortcuts.xml
+++ b/MUSHclient/worlds/plugins/aard_vital_shortcuts.xml
@@ -139,7 +139,6 @@ end
 
 
 function their_stats(who, stat)
-   local what = who.." "..stat:lower()
    local group_members = gmcp("group.members")
    if group_members == "" then
       return
@@ -154,6 +153,7 @@ function their_stats(who, stat)
    if member == nil then
       return
    end
+   local what = member.name .. " " .. stat:lower()
    local current, max = member_stats(member, stat)
    return what, current, max
 end


### PR DESCRIPTION
@fiendish Previously, users had to type a group member's full name to read their vitals. This change will allow them to enter just the first few characters. Also very slightly modified the output to show the full name of the character, rather than the potentially shortened form.