### PR TITLE
Powerup Trigger Updates

### DIFF
--- a/MUSHclient/worlds/plugins/aard_soundpack.xml
+++ b/MUSHclient/worlds/plugins/aard_soundpack.xml
@@ -469,7 +469,7 @@
   <trigger
    enabled="n"
    group="Alert"
-   match="^Congratulations, hero\. You have increased your powers\!$"
+   match="^Congratulations, \w+\. You have increased your powerups to \d+\.$"
    name="PowerUp"
    regexp="y"
    send_to="12"

--- a/MUSHclient/worlds/plugins/aard_vi_review_buffers.xml
+++ b/MUSHclient/worlds/plugins/aard_vi_review_buffers.xml
@@ -477,15 +477,16 @@ category. You could also create your own category.
   <trigger
    enabled="y"
    group="Alert"
-   match="^Congratulations, hero. You have increased your powers!$"
+   match="^Congratulations, \w+\. You have increased your powerups to (\d+)\.$"
    name="PupTrigger"
    regexp="y"
    send_to="12"
    sequence="100"
   >
   <send>
-   review_addline("All", "%0")
-   review_addline("Kill Summary", "%0")
+   local msg = "Powerup #%1"
+   review_addline("All", msg)
+   review_addline("Kill Summary", msg)
   </send>
   </trigger>
 


### PR DESCRIPTION
Update trigger match strings in the Aardwolf_Soundpack and Aardwolf_Review_Buffers plugins so that they don't miss powerup notifications. That message was changed in the 15 July reboot.

Also very slightly modify the powerup trigger body in Review Buffers to save an abbreviated form of the message for faster review, since having to hear "Congratulations, player. You have increased your powerups to..." is sort of a lot.

P.S., @fiendish - I did a quick check for any other plugins that might've been so affected and found none.