### PR TITLE
GMCP Mapper: Add distance to printpath output

### DIFF
--- a/MUSHclient/worlds/plugins/aard_GMCP_mapper.xml
+++ b/MUSHclient/worlds/plugins/aard_GMCP_mapper.xml
@@ -4481,18 +4481,20 @@ function printpath(src, dest)
    speedwalk = table.concat(split_speedwalk, " ; ")
 
    -- count directions + cexits
+   local distanceOuput = ""
    local inputCount = 0
    for _, dir in ipairs (foundpath) do
       inputCount = inputCount + 1
    end
+   distanceOutput = string.format("Distance: %s\n", inputCount)
+
 
    -- display it
    if current_room ~= src then
-      mapper.mapprint (string.format ("Path from %s to %s is:\n%s", src, dest, speedwalk))
+      mapper.mapprint (string.format ("Path from %s to %s is:\n%s\n%s", src, dest, speedwalk, distanceOutput))
    else
-      mapper.mapprint (string.format ("Path to %s is:\n%s", dest, speedwalk))
+      mapper.mapprint (string.format ("Path to %s is:\n%s\n%s", dest, speedwalk, distanceOutput))
    end
-   mapper.mapprint (string.format( "Distance: %s\n", inputCount))
 end
 
 function map_where (name, line, wildcards)

--- a/MUSHclient/worlds/plugins/aard_GMCP_mapper.xml
+++ b/MUSHclient/worlds/plugins/aard_GMCP_mapper.xml
@@ -4481,19 +4481,18 @@ function printpath(src, dest)
    speedwalk = table.concat(split_speedwalk, " ; ")
 
    -- count directions + cexits
-   local distanceOuput = ""
-   local inputCount = 0
+   local distance_ouput = ""
+   local input_count = 0
    for _, dir in ipairs (foundpath) do
-      inputCount = inputCount + 1
+      input_count = input_count + 1
    end
-   distanceOutput = string.format("Distance: %s\n", inputCount)
-
+   distance_ouput = string.format("Distance: %s\n", input_count)
 
    -- display it
    if current_room ~= src then
-      mapper.mapprint (string.format ("Path from %s to %s is:\n%s\n%s", src, dest, speedwalk, distanceOutput))
+      mapper.mapprint (string.format ("Path from %s to %s is:\n%s\n%s", src, dest, speedwalk, distance_ouput))
    else
-      mapper.mapprint (string.format ("Path to %s is:\n%s\n%s", dest, speedwalk, distanceOutput))
+      mapper.mapprint (string.format ("Path to %s is:\n%s\n%s", dest, speedwalk, distance_ouput))
    end
 end
 

--- a/MUSHclient/worlds/plugins/aard_GMCP_mapper.xml
+++ b/MUSHclient/worlds/plugins/aard_GMCP_mapper.xml
@@ -4480,12 +4480,19 @@ function printpath(src, dest)
 
    speedwalk = table.concat(split_speedwalk, " ; ")
 
+   -- count directions + cexits
+   local inputCount = 0
+   for _, dir in ipairs (foundpath) do
+      inputCount = inputCount + 1
+   end
+
    -- display it
    if current_room ~= src then
-      mapper.mapprint (string.format ("Path from %s to %s is:\n%s\n", src, dest, speedwalk))
+      mapper.mapprint (string.format ("Path from %s to %s is:\n%s", src, dest, speedwalk))
    else
-      mapper.mapprint (string.format ("Path to %s is:\n%s\n", dest, speedwalk))
+      mapper.mapprint (string.format ("Path to %s is:\n%s", dest, speedwalk))
    end
+   mapper.mapprint (string.format( "Distance: %s\n", inputCount))
 end
 
 function map_where (name, line, wildcards)


### PR DESCRIPTION
findpath is useful for determining which routes to areas are longer than others.  This gives a bit easier indicator as to distance.  It's not 100% accurate due to cexits potentially causing script execution, but since the speedwalk is still displayed it seems reasonable enough.

I considered parsing out `;` in directions to give a better picture of cexits but that seemed like a rabbit hole and still wouldn't give 100% accuracy, so left it with the notion of "Distance = dirs + cexits"

### Testing


```
> mapper findpath 1 100

Path from 1 to 100 is:
portal 3131351669 ; op n ; n ; run 2n u
Distance: 5
```
5 here is Portal cexit + "op n;;n cexit" + n + n + u
```
> mapper findpath 32418 31254

Path from 32418 to 31254 is:
portal 3131008899 ; run s d 6s 13e ; enter fog
Distance: 23
```

Current room is source
```
> mapper findpath 32418 31254

Path to 31254 is:
portal 3131008899 ; run s d 6s 13e ; enter fog
Distance: 23
```
