### PR TITLE
Fix wrapped_captures to handle apostrophes in start tag

### DIFF
--- a/MUSHclient/lua/wrapped_captures.lua
+++ b/MUSHclient/lua/wrapped_captures.lua
@@ -197,10 +197,14 @@ function command(
    }
 
    -- start trigger
+   local trigger_response = [===[
+      Capture.___create_capture("%d", "%%0")
+      StopEvaluatingTriggers(true)
+   ]===]
    AddTriggerEx(
       "tag_captures_module___start_"..i,
       echo_prefix..capture_start_tag,
-      "Capture.___create_capture('"..i.."', '%0');StopEvaluatingTriggers(true)",
+      trigger_response:format(i),
       trigger_flag.OmitFromLog + trigger_flag.OmitFromOutput + trigger_flag.Temporary + trigger_flag.Enabled + trigger_flag.OneShot + (tags_are_regexp and trigger_flag.RegularExpression or 0),
       -1, 0, "", "", sendto.script, ___storage[i]["sequence_low"]
    )


### PR DESCRIPTION
### Fix Issue

Fixes #334

### Summary

Apostrophes in a line used as a start tag with tagged_output would potentially cause an error due to the way the start tag trigger's response script was constructed. Form it instead by wrapping it in Lua's bracket quotes so that quote characters are handled correctly.