### PR TITLE
Fix: 'mapper purge cexits area' deletes standard exits, not just custom

### DIFF
--- a/MUSHclient/worlds/plugins/aard_GMCP_mapper.xml
+++ b/MUSHclient/worlds/plugins/aard_GMCP_mapper.xml
@@ -1381,7 +1381,11 @@ function map_cexits_purge (name, line, wildcards)
    if not wildcards then
       query = "delete from exits where dir not in ('n','s','e','w','d','u');"
    else
-      query = "delete from exits where fromuid in (select e.fromuid from exits e join rooms r on e.fromuid = r.uid where r.area = '" .. wildcards[1] .. "' and e.dir not in ('n','s','e','w','d','u'));"
+      -- The dir filter must constrain the DELETE itself. Constraining only the
+      -- sub-select identifies every room that *contains* a custom exit, and the
+      -- outer DELETE then removes ALL exits from those rooms -- including their
+      -- standard n/s/e/w/u/d exits, silently corrupting the speedwalk graph.
+      query = "delete from exits where dir not in ('n','s','e','w','d','u') and fromuid in (select uid from rooms where area = '" .. wildcards[1] .. "');"
       pString = "Purged all area custom exits."
    end
 


### PR DESCRIPTION
# PR 1 — `mapper purge cexits area` deletes standard exits, not just custom

**Branch:** `rodarvus:fix/cexits-purge-area-deletes-standard-exits`
**Base:** `fiendish/aardwolfclientpackage:MUSHclient`
**File:** `MUSHclient/worlds/plugins/aard_GMCP_mapper.xml` — `map_cexits_purge()`
**Severity:** High — silent, persistent map-data loss.

---

## Summary

`mapper purge cexits area` should remove only **custom** exits from the rooms of
the current area. Instead it deletes **every** exit — including standard
`n/s/e/w/u/d` — from any room that merely *contains* a custom exit. The room
stays walkable in-game, but the mapper's stored graph loses the cardinal links,
so `mapper goto <room>` into that area can no longer find a path even though the
player can walk there by hand.

## Root cause

The area branch builds:

```lua
delete from exits
where fromuid in (
   select e.fromuid from exits e join rooms r on e.fromuid = r.uid
   where r.area = '<area>' and e.dir not in ('n','s','e','w','d','u')
);
```

The `dir not in (...)` predicate is inside the **sub-SELECT**, which only decides
*which rooms* to act on. It resolves to "every room in the area that has at least
one custom exit." The outer `DELETE` then has **no** dir predicate, so it removes
**all** exits from those rooms — standard directions included.

The global branch (`purge cexits`, no area) is correct because it puts the dir
filter on the `DELETE` itself.

### Why the damage is silent and persistent
After the delete, standard exits are not auto-relearned within the session: the
in-memory `rooms` cache still lists them, so the GMCP-vs-cache equality check in
`got_gmcp_room()` (`same_exits`) sees "no change" and never re-saves. The exits
only return after a plugin reload + revisit, or by restoring the DB. (The cache
side of this is addressed independently in the sibling PR, #344.)

## Fix

Move the dir predicate onto the outer `DELETE`; reduce the sub-SELECT to a plain
area→room lookup:

```lua
delete from exits
where dir not in ('n','s','e','w','d','u')
  and fromuid in (select uid from rooms where area = '<area>');
```

Now only custom exits in the target area are removed. This matches the documented
intent and the single-room `mapper delete cexits` command, which already filters
`dir` on the `DELETE`.

## Diff

```diff
    else
-      query = "delete from exits where fromuid in (select e.fromuid from exits e join rooms r on e.fromuid = r.uid where r.area = '" .. wildcards[1] .. "' and e.dir not in ('n','s','e','w','d','u'));"
+      -- The dir filter must constrain the DELETE itself. Constraining only the
+      -- sub-select identifies every room that *contains* a custom exit, and the
+      -- outer DELETE then removes ALL exits from those rooms -- including their
+      -- standard n/s/e/w/u/d exits, silently corrupting the speedwalk graph.
+      query = "delete from exits where dir not in ('n','s','e','w','d','u') and fromuid in (select uid from rooms where area = '" .. wildcards[1] .. "');"
       pString = "Purged all area custom exits."
    end
```

## Validation

Standalone SQLite reproduction (`repro_cexits.py`) mirroring the real
`rooms`/`exits` schema. Scenario: a desolation room with both cardinal and custom
exits, a cardinal-only room, and a custom exit in an unrelated area.

```
before:            8 exits
old query (buggy): 3 exits  -- deleted 2 custom AND 3 collateral cardinals
new query (fixed): 6 exits  -- deleted only the 2 custom exits
```

The unrelated area's custom exit is untouched in both (area scoping preserved).

Real-world incident that prompted this: running the command in *The Mountains of
Desolation* deleted 8 custom + 13 standard exits across 9 rooms, isolating a
60-room sub-region so `mapper goto` failed into it.

### Live test (in-game, 2026-06-05)
Patched mapper loaded in MUSHclient; ran `mapper purge cexits area confirm` in
*The Mountains of Desolation*:

- Area exits went 247 -> 238 — exactly the 9 custom exits removed, **zero**
  standard exits lost.
- Every one of the 9 rooms that had held a custom exit kept its standard exits
  (e.g. 19544 still has `e`/`w`; 19531 still has `n`/`s`). Under the pre-fix code
  these were all deleted.
- `mapper goto` into the area continued to path correctly afterward.
- Global `mapper purge cexits` (no area) behaved as before.

## Scope / risk

- One-line query change; no API or schema change.
- No behavior change to the *intended* feature or to the global purge.
- SQL string interpolation of the area name is intentionally left as-is to keep
  this change minimal and single-purpose (value comes from
  `gmcp("room.info.zone")`, a server-controlled identifier). `fixsql()` hardening
  would be a separate change.
- Live-tested in MUSHclient (2026-06-05) — see the Live test section above.
  Confirmed: only custom exits removed, all standard exits preserved, global
  purge unchanged.
