### PR TITLE
Fix: 'mapper purge cexits area' over-invalidates the in-memory exit cache

### DIFF
--- a/MUSHclient/worlds/plugins/aard_GMCP_mapper.xml
+++ b/MUSHclient/worlds/plugins/aard_GMCP_mapper.xml
@@ -1387,10 +1387,17 @@ function map_cexits_purge (name, line, wildcards)
 
    dbCheckExecute(query)
    for k,v in pairs(rooms) do
-      for l,w in pairs(v.exits) do
-         if not directions[l] then
-            v.exits[l] = nil
-            v.exit_locks[l] = nil
+      -- Match the cache invalidation to what the query actually deleted. For an
+      -- area purge, only touch rooms in that area; otherwise an area-scoped
+      -- purge would also drop custom exits from the in-memory cache of every
+      -- OTHER area (the DB rows survive, so the cache disagrees with the DB
+      -- until the next plugin reload).
+      if (not wildcards) or v.area == wildcards[1] then
+         for l,w in pairs(v.exits) do
+            if not directions[l] then
+               v.exits[l] = nil
+               v.exit_locks[l] = nil
+            end
          end
       end
    end


### PR DESCRIPTION
# PR 2 — `mapper purge cexits area` over-invalidates the in-memory exit cache

**Branch:** `rodarvus:fix/cexits-purge-area-over-broad-cache-invalidation`
**Base:** `fiendish/aardwolfclientpackage:MUSHclient`
**File:** `MUSHclient/worlds/plugins/aard_GMCP_mapper.xml` — `map_cexits_purge()`
**Severity:** Low — session-only cache/DB incoherence; self-heals on plugin reload.

---

## Summary

After the `DELETE`, `map_cexits_purge()` walks the **entire** in-memory `rooms`
cache and strips custom exits from every cached room, ignoring the area argument.
For the global purge that is correct; for the **area** purge it wrongly drops
custom exits from the cache of *every other area* too.

## Root cause

```lua
dbCheckExecute(query)
for k,v in pairs(rooms) do
   for l,w in pairs(v.exits) do
      if not directions[l] then
         v.exits[l] = nil
         v.exit_locks[l] = nil
      end
   end
end
```

The SQL (area branch) deletes only custom exits within the current area, but this
loop has no area guard. Rooms in other areas keep their custom-exit rows in the
**database** while losing them from the **cache** — the two disagree until the
plugin is reloaded (which re-reads rooms from disk). Within the session, an
exit-poor view of unrelated areas is used for drawing and pathfinding.

## Fix

Scope the cache invalidation to match what the query deleted:

```lua
for k,v in pairs(rooms) do
   if (not wildcards) or v.area == wildcards[1] then
      for l,w in pairs(v.exits) do
         if not directions[l] then
            v.exits[l] = nil
            v.exit_locks[l] = nil
         end
      end
   end
end
```

`v.area == wildcards[1]` uses the same area key the SQL uses
(`rooms.area = wildcards[1]`), keeping cache and DB in agreement. The global purge
(`not wildcards`) still touches everything, unchanged.

## Diff

```diff
    dbCheckExecute(query)
    for k,v in pairs(rooms) do
-      for l,w in pairs(v.exits) do
-         if not directions[l] then
-            v.exits[l] = nil
-            v.exit_locks[l] = nil
+      -- Match the cache invalidation to what the query actually deleted. For an
+      -- area purge, only touch rooms in that area; otherwise an area-scoped
+      -- purge would also drop custom exits from the in-memory cache of every
+      -- OTHER area (the DB rows survive, so the cache disagrees with the DB
+      -- until the next plugin reload).
+      if (not wildcards) or v.area == wildcards[1] then
+         for l,w in pairs(v.exits) do
+            if not directions[l] then
+               v.exits[l] = nil
+               v.exit_locks[l] = nil
+            end
          end
       end
    end
```

## Relationship to PR 1 (#343)

Independent of #343. PR 1 fixes the destructive SQL (data loss); PR 2 fixes cache/DB
coherence of the area branch. Each is correct on its own and they touch different
lines (verified: both apply together with no conflict). Either can be merged
first.

## Scope / risk

- Adds an area guard around an existing cache loop; no API or schema change.
- Global purge behavior unchanged.

### Live test (in-game, 2026-06-05)
This patch was loaded in MUSHclient alongside PR 1 and exercised by running
`mapper purge cexits area confirm` in *The Mountains of Desolation*: the area
purge completed correctly, the in-session map of other areas was unaffected, and
no regression was observed. The behavior this PR targets (custom exits dropped
from *other* areas' in-memory cache by an area purge) is session-only and
self-heals on reload, so it is not directly visible in normal play; the change
is a conservative area-scoping guard around the existing loop, with the global
purge path unchanged.
