### PR TITLE
Refresh miniwindow positions before saving and restoring layouts

### DIFF
--- a/MUSHclient/worlds/plugins/aard_layout.xml
+++ b/MUSHclient/worlds/plugins/aard_layout.xml
@@ -184,6 +184,7 @@ end
 
 function LayoutStore(key)
    all_layouts = FetchLayouts()
+   Repaint() -- update rendered miniwindow positions before saving
    miniwindows = WindowList()
    if miniwindows then
       current_layout = {
@@ -223,6 +224,7 @@ function LayoutRestore(key)
       SaveLayout()
       check_geometry()
       draw_main_window()
+      Repaint() -- update rendered miniwindow positions before comparing
       -- do the other plugins
       CallPlugin("abc1a0944ae4af7586ce88dc", "pause") -- repaint buffer plugin
       local plugins_to_reload = {}


### PR DESCRIPTION
Repaint before saving miniwindow positions and before comparing them during layout restore, so visible windows use current rendered coordinates. The reported health bars position failure still needs confirmation in the live client.
